### PR TITLE
[RUIN-82] Clarify how to change the title of exported report

### DIFF
--- a/components/EmailFinalReport.js
+++ b/components/EmailFinalReport.js
@@ -153,7 +153,7 @@ export class EmailFinalReport extends Component {
   // required method that creates components of email screen
   render() {
     const FilenameHeader = () => (
-        <CardHeader title="Please input report filename"/>
+        <CardHeader title="Edit filename below."/>
     )
 
     // const FilenameFooter = (props) => (

--- a/components/SaveToDevice.js
+++ b/components/SaveToDevice.js
@@ -143,7 +143,7 @@ componentDidMount() {
 
   render() {
     const saveReportHeader = () => (
-      <CardHeader title="Please input report filename" />
+      <CardHeader title="Edit filename below." />
     )
 
     return(


### PR DESCRIPTION
# Description

Currently, the wording for editing the final report's name is not clear. The header on the page says, "Please input report filename". The user is left wondering where to input the report name. The current filename is listed underneath this statement. To make it clearer to the user where the editable filename is located, the wording on the header is different. Now the header reads: "Edit filename below." 

# Images

### Before
![image](https://user-images.githubusercontent.com/42981026/135013084-4fa103ae-8897-4969-bc62-7a2807814bd6.png)

### After
![image](https://user-images.githubusercontent.com/42981026/135013139-d8e017cf-5366-4d6a-9a97-ebc0c43c94f3.png)

# Testing

1. Create a blank form.
2. Export form.
3. Click "Save to Local Device"
4. Header should have the text: "Edit filename below."
5. Click the back arrow.
6. Click "Email Report"
7. Header should have the text: "Edit filename below."