### PR TITLE
[RUIN-86] Update style of bottom text, bottom text content, and header text

### DIFF
--- a/components/home/Welcome.js
+++ b/components/home/Welcome.js
@@ -85,7 +85,7 @@ class Welcome extends Component {
         } else {
           return (
             <SafeAreaView style={{ flex: 1 }}>
-              <TopNavigation title='Welcome' alignment='center' />
+              <TopNavigation title='RUINA' alignment='center' />
               <Divider />
               <Layout style={styles.centeredContainer}>
                 <View style={styles.btnContainer}>
@@ -98,7 +98,7 @@ class Welcome extends Component {
               <Layout style={styles.bottomBar}>
                 <TouchableOpacity onPress={() => Linking.openURL('https://forms.gle/ho3cZNyoaFArNNN79')}><Text style={{ color: 'blue' }}>Submit Feedback</Text></TouchableOpacity>
                 <Text style={styles.bottomBarText}>
-                  {"Built by students at Olin College of Engineering 2020-2021"}
+                  {"Built by students at Olin College of Engineering in partnership with the Volpe Center and Santos Family Foundation"}
                 </Text>
               </Layout>
 

--- a/components/home/Welcome.style.js
+++ b/components/home/Welcome.style.js
@@ -35,6 +35,8 @@ export const styles = StyleSheet.create({
       alignItems: 'center',
     },
     bottomBarText:{
-      color: '#A9A9A9',
+      color: '#5b5b5b',
+      fontSize: 10,
+      textAlign: 'center'
     },
   });


### PR DESCRIPTION
# Description
Currently, the styling for the welcome page is very bare and awkwardly styled. This change modifies the style so that the bottom text correctly attributes all of our partners and is centered below the feedback form submission line. It also changes the text of the header to be "RUINA" rather than "Welcome", so there is a slightly more descriptive name. This change also addresses tickets RUIN-107, RUIN-108, and RUIN-121.

The welcome page is still quite sparse and future additions would probably be good.

# Testing
Checkout the branch and load the app.