### PR TITLE
[RUIN-33] Auto-save in-progress report with unique file name

### DIFF
--- a/utils/backgroundSave.js
+++ b/utils/backgroundSave.js
@@ -4,10 +4,9 @@ export class backgroundSave extends Component {
     constructor(props) {
         super(props);
         var date = new Date();
-        var localTime = date.toLocaleTimeString().replace(/\W/g, '.');
         var localDate = date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
         this.RNFS = require('react-native-fs');
-        this.path = this.RNFS.DocumentDirectoryPath + "/CrashReport" + localDate + "At" + localTime;
+        this.path = this.RNFS.DocumentDirectoryPath + '/CrashReport'+localDate+'.json';
     }
 
     async captureCurrentState(data){

--- a/utils/backgroundSave.js
+++ b/utils/backgroundSave.js
@@ -3,8 +3,11 @@ import { Component } from 'react';
 export class backgroundSave extends Component {
     constructor(props) {
         super(props);
-        this.RNFS = require('react-native-fs'); 
-        this.path = this.RNFS.DocumentDirectoryPath + '/unfinished_report.json';
+        var date = new Date();
+        var localTime = date.toLocaleTimeString().replace(/\W/g, '.');
+        var localDate = date.getFullYear() + "-" + (date.getMonth() + 1) + "-" + date.getDate();
+        this.RNFS = require('react-native-fs');
+        this.path = this.RNFS.DocumentDirectoryPath + "/CrashReport" + localDate + "At" + localTime;
     }
 
     async captureCurrentState(data){


### PR DESCRIPTION
# Description

Previously all forms were set to be saved to `unfinished_report.json`. The app checks for this specific file path when it tries to re-open a previous session. As a precursor to having multiple reports open, the app needs to save the report under a unique name. Now the app saves the file as `CrashReport{year-moth-day}.json`. This is not exactly unique if there are multiple reports that happen for one day, but it is more unique than the previous naming convention.

# Images
n/a

# Testing

1. Open the app
2. Open the terminal to watch the logs
3. Start a new app and quick survey page
4. Check the log for the following structure (the filename may vary slightly):
   `Current state saved to: /data/user/0/com.ruina/files/CrashReport2021-10-2.json
5. Force close the app
6. Reopen app
7. Pop up should display asking if you would like to resume the last session
8. Click Yes
9. Click Continue
10. Check log to see that the logged file path matches the one in step 4