### PR TITLE
fix/CaseyJMay/AddSingleTooltip

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,7 +19,8 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 MYAPP_UPLOAD_STORE_FILE=scope-upload-key.keystore
 MYAPP_UPLOAD_KEY_ALIAS=scope-key-alias
+org.gradle.java.home=C:\\Program Files\\Eclipse Foundation\\jdk-16.0.2.7-hotspot\\
+org.gradle.jvmargs=-Xmx1536M --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/data/questions.js
+++ b/data/questions.js
@@ -705,7 +705,7 @@ export const questions = {
                 "driver"
             ],
             "humanReadableId": "driver-26",
-            "helperText": "Provide the specific State, Province or Nation indicated on the Driver's License0",
+            "helperText": "Provide the specific State, Province or Nation indicated on the Driver's License",
             "tooltip": "See Appendix E: ANSI State FIPS and USPS Codes or Appendix F: ISO 3166-2 Codes for Canada and Mexico"
         },
         {
@@ -3446,6 +3446,7 @@ export const questions = {
             ],
             "humanReadableId": "road-8",
             "helperText": "(YYYYMMDDHHMM)",
+            "tooltip": "Ex: 202110031027 is 10:27 on October 3, 2021",
             "autoMethod": "time"
         },
         {

--- a/data/questions.js
+++ b/data/questions.js
@@ -705,7 +705,8 @@ export const questions = {
                 "driver"
             ],
             "humanReadableId": "driver-26",
-            "helperText": "Provide the specific State, Province or Nation indicated on the Driver's License (see Appendix E: ANSI State FIPS and USPS Codes or Appendix F: ISO 3166-2 Codes for Canada and Mexico)"
+            "helperText": "Provide the specific State, Province or Nation indicated on the Driver's License0",
+            "tooltip": "See Appendix E: ANSI State FIPS and USPS Codes or Appendix F: ISO 3166-2 Codes for Canada and Mexico"
         },
         {
             "numOptionsAllowed": "0.0",

--- a/ios/Ruina.xcodeproj/project.pbxproj
+++ b/ios/Ruina.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* RuinaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* RuinaTests.m */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };


### PR DESCRIPTION
# **Description**
Previously, in the crash date and time section of questions.js, there was no tooltip on the "Crash Date and Time" question. I added a single tooltip to show an example of the date/time format, so that we wouldn't receive any wrong formats prior to our eventual validation. 
# **Image**
![image](https://user-images.githubusercontent.com/42981072/135758950-8dd9ce02-8ddb-45b0-be8a-73b38f32c713.png)
Current appearance, with the change
# **Testing**
1. Open the app
2. Navigate through the first page, and select the "Crash and Roadway" section on the next page.
3. Scroll down to the "Crash Date and Time" section, the first question there should look like the image above, the tooltip should show an example of what the format looks like with an example date.
