### PR TITLE
[RUIN-104] Fix file type list format

### DIFF
--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -79,21 +79,21 @@ class FinalReport extends Component {
                   </Card>
 
                   <SinglePickerMaterialDialog
-                      title={"Choose report export format"}
-                      scrolled
-                      items={file_format_extensions.map((row, index) => ({ value: index, label: row }))}
-                      visible={this.state.chooseReportFormatVisible}
-                      selectedItem={this.state.chooseReportFormatSelectedItem}
-                      onCancel={() => this.setState({ chooseReportFormatVisible: false })}
-                      onOk={result => {
-                          this.setState({ chooseReportFormatSelectedItem: result.selectedItem});
-                          this.setState({ chooseReportFormatVisible: false });
-                          console.log('selected:', this.state.chooseReportFormatSelectedItem);
-                          console.log('result:', result.selectedItem);
-                          console.log('pop up window state:', this.state.chooseReportFormatVisible);
-                          this.state.exportAction(result.selectedItem.label);
-                      }}
-                  />
+                        title={"Choose report export format"}
+                        scrolled
+                        items={file_format_extensions.map((row, index) => ({ value: index, label: "." + row }))}
+                        visible={this.state.chooseReportFormatVisible}
+                        selectedItem={this.state.chooseReportFormatSelectedItem}
+                        onCancel={() => this.setState({ chooseReportFormatVisible: false })}
+                        onOk={result => {
+                            this.setState({ chooseReportFormatSelectedItem: result.selectedItem});
+                            this.setState({ chooseReportFormatVisible: false });
+                            console.log('selected:', this.state.chooseReportFormatSelectedItem);
+                            console.log('result:', result.selectedItem);
+                            console.log('pop up window state:', this.state.chooseReportFormatVisible);
+                            this.state.exportAction(result.selectedItem.label.substring(1));
+                        }}
+                    />
                 </ScrollView>
             </SafeAreaView>
         )


### PR DESCRIPTION
# Description

Previously when a user chose to export their completed report via email or save locally, they were prompted to choose a file type. The way the file type was formated did not follow the standard file extension format. This did not impede the user but is a change to make the app appear more professional. Now the file type options follow the standard format (.pdf, .xlsx, .html)

# Images

## Before
![image](https://user-images.githubusercontent.com/42981026/135764007-bf81e4dd-e92a-4ed7-af05-542974ee9924.png)

## After
![image](https://user-images.githubusercontent.com/42981026/135763960-6d2c1175-ed5b-43d2-a918-564ed43e65cc.png)

# Testing

1. Open the app
2. Reopen or start a report
3. Click through to "Export"
4. Click "Save to Local Device"
5. Each of the file options should follow: .file-extension
6. Click "Cancel".
7. Click "Email Report"
8. Each of the file options should follow: .file-extension