### PR TITLE
[RUIN-96] Disable send report to database button

### DIFF
--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -44,10 +44,10 @@ class FinalReport extends Component {
             navigation.navigate('EmailFinalReport', {format:format})
         }
 
-        const navigateDatabase = (format) => {
-            console.log('SEND REPORT TO DATABASE!');
-            navigation.navigate('ReportToDatabase', {format:format})
-        }
+//        const navigateDatabase = (format) => {
+//            console.log('SEND REPORT TO DATABASE!');
+//            navigation.navigate('ReportToDatabase', {format:format})
+//        }
         const file_format_extensions = Constants.ALLOW_JSON_EXPORT ? ["json", "pdf", "html", "xlsx"] : ["pdf", "html", "xlsx"];
 
         return(
@@ -70,8 +70,8 @@ class FinalReport extends Component {
                       </Button>
                   </Card>
                   <Card header={SaveToDatabaseHeader}>
-                      <Text style={{ marginBottom: 20 }}>Press this button to send the crash report to the database.</Text>
-                      <Button onPress={() => navigateDatabase('JSON')}>Send Report To Database</Button>
+                      <Text style={{ marginBottom: 20 }}>FEATURE COMING SOON</Text>
+                      <Button onPress={() => navigateDatabase('JSON')} disabled>Send Report To Database</Button>
                   </Card>
                   <Card header={FeedbackHeader} style={{marginTop:20}}>
                     <Text style={{marginBottom: 20}}>Tell us what you liked and what you didn't like so we can make your experience better.</Text>


### PR DESCRIPTION
# Description

The current button to save to a database does not prepare the data and connect to a database. The button leads to a blank page that tells the user that this function is not available with a go-back button at the bottom of the page. Now the button is disabled with text above, "FEATURE COMING SOON". The button is disabled rather than commented out to allow the user to know that the feature is being developed. Also when the code was commented out it ran into weird stack trace errors (might want to look into those at another time).

# Images

## Before
![image](https://user-images.githubusercontent.com/42981026/135775621-896b6d17-8a2f-437b-85fc-7f3d7136f4af.png)

## After
![image](https://user-images.githubusercontent.com/42981026/135775763-f414f75b-e17f-4331-9eab-dc6aa4496d54.png)

# Testing
1. Open the app
2. Reopen or start a report
3. Click through to "Export"
4. Click "Save to Database"
5. Nothing should happen
6. The button should be greyed out