### PR TITLE
[RUIN-120] Ask for file permissions before user selects file format

### DIFF
--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -86,7 +86,8 @@ class FinalReport extends Component {
                   <Card header={SaveToDeviceHeader }>
                       <Text style={{ marginBottom: 20 }}>Press this button to save the crash report to local device.</Text>
                       <Button
-                          onPress={() => this.setState({ chooseReportFormatVisible: true, exportAction: navigateSaveToDevice })}>
+                          onPress={() => this.setState({ chooseReportFormatVisible: true, exportAction: navigateSaveToDevice })}
+                          disabled={!this.state.filePermissionsGranted}>
                           Save Report to Local Device
                       </Button>
 
@@ -105,8 +106,7 @@ class FinalReport extends Component {
                   </Card>
                   <Card header={FeedbackHeader} style={{marginTop:20}}>
                     <Text style={{marginBottom: 20}}>Tell us what you liked and what you didn't like so we can make your experience better.</Text>
-                    <Button onPress={()=>Linking.openURL('https://forms.gle/ho3cZNyoaFArNNN79')}
-                    disabled={!this.state.filePermissionsGranted}>Submit Feedback</Button>
+                    <Button onPress={()=>Linking.openURL('https://forms.gle/ho3cZNyoaFArNNN79')}>Submit Feedback</Button>
                   </Card>
 
                   <SinglePickerMaterialDialog

--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -94,8 +94,9 @@ class FinalReport extends Component {
                   <Card header={EmailHeader}>
                       <Text style={{ marginBottom: 20 }}>Press this button to email the crash report.</Text>
                       <Button
-                          onPress={() => this.setState({ chooseReportFormatVisible: true, exportAction: navigateEmail })}>
-                          Email Report
+                        onPress={() => this.setState({ chooseReportFormatVisible: true, exportAction: navigateEmail })}
+                        disabled={!this.state.filePermissionsGranted}>
+                            Email Report
                       </Button>
                   </Card>
                   <Card header={SaveToDatabaseHeader}>
@@ -104,7 +105,8 @@ class FinalReport extends Component {
                   </Card>
                   <Card header={FeedbackHeader} style={{marginTop:20}}>
                     <Text style={{marginBottom: 20}}>Tell us what you liked and what you didn't like so we can make your experience better.</Text>
-                    <Button onPress={()=>Linking.openURL('https://forms.gle/ho3cZNyoaFArNNN79')}>Submit Feedback</Button>
+                    <Button onPress={()=>Linking.openURL('https://forms.gle/ho3cZNyoaFArNNN79')}
+                    disabled={!this.state.filePermissionsGranted}>Submit Feedback</Button>
                   </Card>
 
                   <SinglePickerMaterialDialog

--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -13,6 +13,8 @@ class FinalReport extends Component {
             chooseReportFormatVisible: false,
             chooseReportFormatSelectedItem: undefined,
             exportAction: undefined,
+            filePermissionsGranted: false,
+            filePermissionsErrorMessageVisible: false
         };
         this.requestExternalStoragePermission();
     }
@@ -32,8 +34,11 @@ class FinalReport extends Component {
           );
           if (granted === PermissionsAndroid.RESULTS.GRANTED) {
             console.log("You can use external storage");
+            this.setState({ filePermissionsGranted: true });
           } else {
             console.log("external permission denied");
+            this.setState({ filePermissionsGranted: false });
+            this.setState({ filePermissionsErrorMessageVisible: true });
           }
         } catch (err) {
           console.warn(err);
@@ -106,7 +111,7 @@ class FinalReport extends Component {
                         title={"Choose report export format"}
                         scrolled
                         items={file_format_extensions.map((row, index) => ({ value: index, label: "." + row }))}
-                        visible={this.state.chooseReportFormatVisible}
+                        visible={this.state.chooseReportFormatVisible && this.state.filePermissionsGranted}
                         selectedItem={this.state.chooseReportFormatSelectedItem}
                         onCancel={() => this.setState({ chooseReportFormatVisible: false })}
                         onOk={result => {

--- a/components/FinalReport.js
+++ b/components/FinalReport.js
@@ -1,8 +1,8 @@
 import React, {Component} from 'react';
 import { SafeAreaView } from 'react-navigation';
 import { connect } from 'react-redux';
-import {TopNavigation,Card, CardHeader, Text, Button} from '@ui-kitten/components';
-import {StyleSheet, Linking, ScrollView} from 'react-native';
+import { TopNavigation,Card, CardHeader, Text, Button } from '@ui-kitten/components';
+import { StyleSheet, Linking, ScrollView, PermissionsAndroid } from 'react-native';
 import { MaterialDialog, SinglePickerMaterialDialog} from 'react-native-material-dialog';
 import * as Constants from '../constants';
 
@@ -14,7 +14,31 @@ class FinalReport extends Component {
             chooseReportFormatSelectedItem: undefined,
             exportAction: undefined,
         };
+        this.requestExternalStoragePermission();
     }
+
+    requestExternalStoragePermission = async () => {
+        try {
+          const granted = await PermissionsAndroid.request(
+            PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+            {
+              title: "Android External Storage Permission",
+              message:
+                "Ruina needs access to your external storage to save the report ",
+              buttonNeutral: "Ask Me Later",
+              buttonNegative: "Cancel",
+              buttonPositive: "OK"
+            }
+          );
+          if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+            console.log("You can use external storage");
+          } else {
+            console.log("external permission denied");
+          }
+        } catch (err) {
+          console.warn(err);
+        }
+      };
 
     render(){
         const {

--- a/components/SaveToDevice.js
+++ b/components/SaveToDevice.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import { SafeAreaView } from 'react-navigation';
 import { connect } from 'react-redux';
 import {TopNavigation, Card, CardHeader, Text, Button} from '@ui-kitten/components';
-import { Platform, StyleSheet, View, TextInput, PermissionsAndroid, Dimensions } from 'react-native';
+import { Platform, StyleSheet, View, TextInput, Dimensions } from 'react-native';
 import { MaterialDialog } from 'react-native-material-dialog';
 import { material } from "react-native-typography";
 import Pdf from 'react-native-pdf';
@@ -79,29 +79,6 @@ componentDidMount() {
     this.setState({ filename: text });
   }
 
-  requestExternalStoragePermission = async () => {
-    try {
-      const granted = await PermissionsAndroid.request(
-        PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
-        {
-          title: "Android External Storage Permission",
-          message:
-            "Ruina needs access to your external storage to save the report ",
-          buttonNeutral: "Ask Me Later",
-          buttonNegative: "Cancel",
-          buttonPositive: "OK"
-        }
-      );
-      if (granted === PermissionsAndroid.RESULTS.GRANTED) {
-        console.log("You can use external storage");
-      } else {
-        console.log("external permission denied");
-      }
-    } catch (err) {
-      console.warn(err);
-    }
-  };
-
   async saveData() {
       const format = this.props.navigation.state.params.format;
       var device_platform = Platform.OS
@@ -119,7 +96,6 @@ componentDidMount() {
         path = path_ios;
       } else {
         path = path_android;
-        this.requestExternalStoragePermission();
       }
 
       // write the file and save to Files app on device:


### PR DESCRIPTION
# Description

This change moves the request for file permissions from Save to Device screen to the Export options screen. This ensures that before the user can save a report to the device, we have already requested permissions, creating a more intuitive flow.

# Testing
1. Create or reopen a report.
2. Navigate to the Export screen.
3. Check to see if a pop-up asking for file permissions appears.
4. Allow permissions.
5. Select save to local device.
6. Select a file format and save the report.
7. Check to see if the file is saved successfully.