### PR TITLE
[RUIN-35] Remove Auto-delete

### DIFF
--- a/components/modules/quickSurvey/QuickSurvey.js
+++ b/components/modules/quickSurvey/QuickSurvey.js
@@ -49,7 +49,7 @@ class QuickSurvey extends Component {
         await this.loadStateFromJSON();
       } else {
         // Delete previous auto saved session if there is any, so we can save the new report
-        this.stateManager.deleteCapturedState();
+//        this.stateManager.deleteCapturedState();
         this.setState({ loading: false });
       }
     }
@@ -66,14 +66,14 @@ class QuickSurvey extends Component {
             // catch any error while parsing the JSON
             console.log("ERROR: " + e.message);
             this.setState({ loadedAutoSaveFailMessageVisible: true })
-            this.stateManager.deleteCapturedState();
+//            this.stateManager.deleteCapturedState();
           }
           // Hide loading screen
           this.setState({ loading: false });
         })
         .catch((err) => {
           // catch any error while reading autoSavedSession JSON from disk
-          this.stateManager.deleteCapturedState();
+//          this.stateManager.deleteCapturedState();
           this.setState({ autoSavedSession: false });
           this.setState({ loading: false });
           this.setState({ loadedAutoSaveFailMessageVisible: true })


### PR DESCRIPTION
# Description

When the app loads with an unfinished report, it will automatically delete the current file that exists so that there are no saving conflicts. We no longer want this functionality because it will prevent the saving of multiple reports. The lines are currently commented out as we might want to use them in the future to prompt users to delete files and auto-deleting corrupted files.

# Testing

1. Open the app
2. Click "Start New Report"
3. Check the console log, should be empty
4. Fill out a portion of the form
5. Force close the app
6. Open the app
7. Click "No" to not continue the unfinished report
8. Check the console log, should be empty