### PR TITLE
[RUIN-117] Remove vehicle icon from the configuration screen

### DIFF
--- a/components/home/homeSections/VehicleSection.js
+++ b/components/home/homeSections/VehicleSection.js
@@ -131,10 +131,6 @@ class VehicleSection extends Component{
             return(
                 <Card key={vehicle.id} header={VehiclesHeader} style={styles.itemCard} >
                     <View style={styles.itemCardContent}>
-                        <Card style={styles.individualCard}>
-                            <Icon name='car' opacity={0.5} width={75} height={75} style={{justifyItems:'center', alignItems:'center'}}/>
-                            <Text style={styles.itemCardFooter} category="s1">{name}</Text>
-                        </Card>
                         {!this.state.driverDeleted &&
                           <Card style={styles.individualCardRemove} onPress= {() => this.setState({beforeDriverDelete:true})}>
                               <Icon name='person-remove' width={75} height={75} float alignSelf= "center" fill='white'/>


### PR DESCRIPTION
# Description
On the page after the Quick Survey (the configuration screen) the user sees a list of icons that are pre-populated based on vehicle and non-motorists sections. In the vehicle section, there is a vehicle icon that is styled like the driver and passenger buttons. The styling of the icon confuses the user and makes them think that the icon should be a button. The icon also does not serve any purpose other than helping the user know that it is a vehicle section. Now the icon is gone.

# Images

## Before
![image](https://user-images.githubusercontent.com/42981026/136639602-4b3a2e50-948c-49a0-b823-7d23ea143a91.png)

## After
![image](https://user-images.githubusercontent.com/42981026/136639552-ff4f1fe1-4dca-4531-b9b5-15548580a7ed.png)

# Testing

1. Open a report
2. Add a vehicle to the report
3. Click "Confirm Changes"
4. Vehicle 1 Section should not have a car icon