### PR TITLE
[RUIN-131] Modify a number of vehicle questions to be NumberButtonSelectors

### DIFF
--- a/components/buttonSelectors/NumberButtonSelector.js
+++ b/components/buttonSelectors/NumberButtonSelector.js
@@ -1,22 +1,35 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Button, Text, Layout, Card, CardHeader, Input } from '@ui-kitten/components';
-import { genericWriteAction } from '../../actions/GenericAction';
+//import { genericWriteAction } from '../../actions/GenericAction';
 import {styles} from './NumberButtonSelector.style'
 import { ScrollView } from 'react-native-gesture-handler';
 import { View } from 'react-native';
-
+import { updateResponse } from '../../actions/StoryActions';
 
 
 const NumberButtonSelector = (props) => {
     const [visible, setVisible] = React.useState(false);
     const [selection, setSelection] = React.useState('');
-    const {title, data, id, submitFunction, genericReducer, fieldName, updateResponse, dependencyID} = props;
-    // let currId = data.id
+    const {data, id, submitFunction, questionReducer, fieldName, updateResponse, dependencyID} = props;
+
+    let currId = data.id
+    let status = 'danger'
 
     // if(genericReducer[fieldName] != null & selection != genericReducer[fieldName]) {
     //     setSelection(genericReducer[fieldName]);
     // }
+    const reducerData = questionReducer.data.find(entry => entry.id == id);
+    let existingData = !reducerData?.response ? null: reducerData.response;
+
+    // Populate if value already exists in redux
+    if(!selection) {
+        if(existingData != null) {
+            if(existingData[currId] != selection) {
+                setSelection(existingData[currId]);
+            }
+        }
+    }
 
     const submitField = (val) => {
         setSelection(val);
@@ -26,7 +39,19 @@ const NumberButtonSelector = (props) => {
         } else{
             updateResponse && updateResponse({id, question: currId, selection: val})
         }
-        submitFunction(val);
+        submitFunction({id, question: currId, selection: val});
+    }
+
+    if(!existingData) {
+        status = 'danger'
+    } else {
+        if(!existingData[currId]) {
+            status = 'danger';
+        } else if(existingData[currId] != selection) {
+            status = 'danger'
+        } else {
+            status = 'success'
+        }
     }
 
     const ModalContent = () => {
@@ -107,42 +132,53 @@ const NumberButtonSelector = (props) => {
     };
 
     const Header = () => (
-        <CardHeader title={title}/>
+        <CardHeader title={data.question}/>
     );
 
     return (
-        <Card header={Header}>
-            <View style={{flex: 1, flexDirection:"row"}}>
-                <ScrollView horizontal={true} showsHorizontalScrollIndicator={true} contentContainerStyle={styles.container}>
-                    <View style={styles.buttonSection}>
-                        <Button style={styles.buttonStyle} appearance={(selection == '0') ? 'filled':'outline'} onPress={() => submitField('0')}>None</Button>
-                        <Button style={styles.buttonStyle} appearance={(selection == '1') ? 'filled':'outline'} onPress={() => submitField('1')}>1</Button>
-                        <Button style={styles.buttonStyle} appearance={(selection == '2') ? 'filled':'outline'} onPress={() => submitField('2')}>2</Button>
-                        <Button style={styles.buttonStyle} appearance={(selection == '3') ? 'filled':'outline'} onPress={() => submitField('3')}>3</Button>
-                        <Button style={styles.buttonStyle} appearance={(selection == '4') ? 'filled':'outline'} onPress={() => submitField('4')}>4</Button>
-                        <Button style={styles.buttonStyle} appearance={(selection == '5') ? 'filled':'outline'} onPress={() => submitField('5')}>5</Button>
-                    </View>
-                    <View style={styles.questionInput}>
-                        <Input 
-                            placeholder = "other"
-                            onChangeText = {submitField}
-                            value = {(selection > 5) ? selection:''}
-                            status={(selection > 5) ? 'primary':'basic'}
-                        />
-                    </View>
-                </ScrollView>
-            </View>
-        </Card>
+        <Layout style={styles.container}>
+            <Card header={Header} status={status}>
+                <Layout style={styles.content}>
+                        {HelperTooltip()}
+                        <Layout style={styles.input}>
+                    <ScrollView horizontal={true} showsHorizontalScrollIndicator={true} contentContainerStyle={styles.container}>
+
+                            <Layout style={styles.buttonSection}>
+                                <Button style={styles.buttonStyle} appearance={(selection == '0') ? 'filled':'outline'} onPress={() => submitField('0')}>None</Button>
+                                <Button style={styles.buttonStyle} appearance={(selection == '1') ? 'filled':'outline'} onPress={() => submitField('1')}>1</Button>
+                                <Button style={styles.buttonStyle} appearance={(selection == '2') ? 'filled':'outline'} onPress={() => submitField('2')}>2</Button>
+                                <Button style={styles.buttonStyle} appearance={(selection == '3') ? 'filled':'outline'} onPress={() => submitField('3')}>3</Button>
+                                <Button style={styles.buttonStyle} appearance={(selection == '4') ? 'filled':'outline'} onPress={() => submitField('4')}>4</Button>
+                                <Button style={styles.buttonStyle} appearance={(selection == '5') ? 'filled':'outline'} onPress={() => submitField('5')}>5</Button>
+                            </Layout>
+                            <Layout style={styles.questionInput}>
+                                <Input
+                                    placeholder = "other"
+                                    onChangeText = {submitField}
+                                    value = {(selection > 5) ? selection:''}
+                                    status={(selection > 5) ? 'primary':'basic'}
+                                />
+                            </Layout>
+                    </ScrollView>
+                        </Layout>
+                </Layout>
+            </Card>
+        </Layout>
     )
 }
 
 const mapDispatchToProps = {
-    genericWriteAction
+//    genericWriteAction
+    updateResponse
 }
 
 const mapStateToProps = (state, props) => {
-    const genericReducer = state[props.reducerName]
-    return { genericReducer }
+//    const genericReducer = state[props.reducerName]
+//    return { genericReducer }
+    const { response } = state.storyReducer
+    const { reducer } = props;
+    const questionReducer = state[reducer];
+    return { questionReducer, response}
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NumberButtonSelector);

--- a/components/buttonSelectors/NumberButtonSelector.style.js
+++ b/components/buttonSelectors/NumberButtonSelector.style.js
@@ -33,6 +33,17 @@ export const styles = StyleSheet.create({
     helperText: {
       margin: 11
     },
+    content: {
+      margin: 10,
+    },
+    input: {
+      marginBottom: 10,
+      height: 'auto',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      flex: 1,
+      flexWrap: 'wrap',
+    },
     questionInput: {
         flex: 2,
         paddingLeft: 10

--- a/components/buttonSelectors/NumberButtonSelectorQuickSurvey.js
+++ b/components/buttonSelectors/NumberButtonSelectorQuickSurvey.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Button, Text, Layout, Card, CardHeader, Input } from '@ui-kitten/components';
+import { genericWriteAction } from '../../actions/GenericAction';
+import {styles} from './NumberButtonSelector.style'
+import { ScrollView } from 'react-native-gesture-handler';
+import { View } from 'react-native';
+
+
+
+const NumberButtonSelector = (props) => {
+    const [visible, setVisible] = React.useState(false);
+    const [selection, setSelection] = React.useState('');
+    const {title, data, id, submitFunction, genericReducer, fieldName, updateResponse, dependencyID} = props;
+    // let currId = data.id
+
+    // if(genericReducer[fieldName] != null & selection != genericReducer[fieldName]) {
+    //     setSelection(genericReducer[fieldName]);
+    // }
+
+    const submitField = (val) => {
+        setSelection(val);
+        if (dependencyID!=null){
+            const vehicleID = dependencyID[1] // Get vehicle id to identify different vehicles
+            updateResponse && updateResponse({id, question: currId, selection: val, vehicleID: vehicleID})
+        } else{
+            updateResponse && updateResponse({id, question: currId, selection: val})
+        }
+        submitFunction(val);
+    }
+
+    const ModalContent = () => {
+        if (data.helperImg != null ){
+            var img = new ImageSelector()
+            const src = img.pathHandler(data.helperImg)
+            return (
+                <View style={styles.imgContainer}>
+                    <Layout style={styles.modalContent}>
+                        <Text>{data.tooltip}</Text>
+                        <Image source={src} style={styles.img}/>
+                    </Layout>
+                </View>
+            )
+        }else{
+            return(
+                <Layout style={styles.modalContent}>
+                    <Text>{data.tooltip}</Text>
+                </Layout>
+            )
+        }
+    };
+
+        const HelperTooltip = () => {
+        if (data.helperText != null && (data.tooltip != null||data.helperImg!=null)){
+            return (
+                <Layout style={styles.container}>
+                    <View style={styles.rowContainer}>
+                        <Text style={styles.helperText}>{data.helperText}</Text>
+                        <Button appearance='ghost' status='primary' icon={InfoIcon} onPress={toggleModal}>
+                            Info
+                        </Button>
+                        <Modal backdropStyle={styles.backdrop} visible={visible}>
+                            <Card style={styles.content} disabled={true}>
+                            {ModalContent()}
+                            <Button appearance='ghost' icon={CloseIcon} onPress={() => setVisible(false)}>
+                                Close
+                            </Button>
+                            </Card>
+                        </Modal>
+                    </View>
+                </Layout>
+            )
+        }
+        else if (data.helperText != null) {
+            return (<Text style={styles.helperText}>{data.helperText}</Text>)
+        }
+        else if (data.tooltip != null || data.helperImg != null) {
+            return (
+                <View style={styles.endRowcontainer}>
+                    <Button  appearance='ghost' status='primary' icon={InfoIcon} onPress={toggleModal}>
+                        Info
+                    </Button>
+                    <Modal backdropStyle={styles.backdrop} visible={visible}>
+                        <Card style={styles.content} disabled={true}>
+                        {ModalContent()}
+                        <Button appearance='ghost' icon={CloseIcon} onPress={() => setVisible(false)}>
+                            Dismiss
+                        </Button>
+                        </Card>
+                    </Modal>
+                </View>
+            )
+        } else {
+            return null;
+        }
+    }
+
+    const InfoIcon = (props) => (
+        <Icon {...props} name='info'/>
+    );
+    const CloseIcon = (props) => (
+        <Icon {...props} name='close-outline'/>
+    );
+
+    const toggleModal = () => {
+        setVisible(!visible);
+    };
+
+    const Header = () => (
+        <CardHeader title={title}/>
+    );
+
+    return (
+        <Card header={Header}>
+            <View style={{flex: 1, flexDirection:"row"}}>
+                <ScrollView horizontal={true} showsHorizontalScrollIndicator={true} contentContainerStyle={styles.container}>
+                    <View style={styles.buttonSection}>
+                        <Button style={styles.buttonStyle} appearance={(selection == '0') ? 'filled':'outline'} onPress={() => submitField('0')}>None</Button>
+                        <Button style={styles.buttonStyle} appearance={(selection == '1') ? 'filled':'outline'} onPress={() => submitField('1')}>1</Button>
+                        <Button style={styles.buttonStyle} appearance={(selection == '2') ? 'filled':'outline'} onPress={() => submitField('2')}>2</Button>
+                        <Button style={styles.buttonStyle} appearance={(selection == '3') ? 'filled':'outline'} onPress={() => submitField('3')}>3</Button>
+                        <Button style={styles.buttonStyle} appearance={(selection == '4') ? 'filled':'outline'} onPress={() => submitField('4')}>4</Button>
+                        <Button style={styles.buttonStyle} appearance={(selection == '5') ? 'filled':'outline'} onPress={() => submitField('5')}>5</Button>
+                    </View>
+                    <View style={styles.questionInput}>
+                        <Input
+                            placeholder = "other"
+                            onChangeText = {submitField}
+                            value = {(selection > 5) ? selection:''}
+                            status={(selection > 5) ? 'primary':'basic'}
+                        />
+                    </View>
+                </ScrollView>
+            </View>
+        </Card>
+    )
+}
+
+const mapDispatchToProps = {
+    genericWriteAction
+}
+
+const mapStateToProps = (state, props) => {
+    const genericReducer = state[props.reducerName]
+    return { genericReducer }
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(NumberButtonSelector);

--- a/components/buttonSelectors/NumberButtonSelectorQuickSurvey.style.js
+++ b/components/buttonSelectors/NumberButtonSelectorQuickSurvey.style.js
@@ -1,0 +1,48 @@
+import {StyleSheet} from 'react-native';
+
+export const styles = StyleSheet.create({
+    backdrop: {
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    modalContent: {
+      padding: 24,
+      alignItems: 'center',
+    },
+    imgContainer:{
+      flexDirection: 'column',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+      textAlign: 'center'
+    },
+    img:{
+      resizeMode: 'center', 
+      width: 250, 
+      height: 250
+    },
+    rowContainer:{
+      flexDirection: 'row',
+    },
+    endRowcontainer: {
+        flexDirection: 'row',
+        justifyContent: 'flex-end'
+    },
+    container: {
+      width: '90%',
+      marginBottom: 10
+    },
+    helperText: {
+      margin: 11
+    },
+    questionInput: {
+        flex: 2,
+        paddingLeft: 10
+        
+    },
+    buttonStyle: {
+        marginRight: 10,
+    },
+    buttonSection: {
+        flexWrap: "wrap",
+        flexDirection:"row"
+    },
+});

--- a/components/modules/QuestionForm.js
+++ b/components/modules/QuestionForm.js
@@ -5,6 +5,7 @@ import { Divider, Layout, TopNavigation } from '@ui-kitten/components';
 import { styles } from '../../containers/AutoComponentContainer.style';
 import { ScrollView } from 'react-native-gesture-handler';
 import MultiButtonSelector from '../buttonSelectors/MultiButtonSelector';
+import NumberButtonSelector from '../buttonSelectors/NumberButtonSelector';
 import AutoCompleteDropDown from '../dropdowns/AutoCompleteDropDown';
 import DropDownSingleSelect from '../dropdowns/DropDownSingleSelect';
 import OpenTextField from '../textFields/OpenTextField';
@@ -86,6 +87,9 @@ const QuestionForm = (props) => {
            ...PublicObj
         },
         multiButton: {
+          ...PublicObj
+        },
+        numberButton: {
           ...PublicObj
         },
         autoCompleteDropdown: {
@@ -200,6 +204,12 @@ const QuestionForm = (props) => {
           return (
             <MultiButtonSelector
               {...props}
+            />
+          )
+        case 'numberButton':
+          return (
+            <NumberButtonSelector
+                {...props}
             />
           )
         case 'autoCompleteDropdown':

--- a/components/modules/quickSurvey/QuickSurvey.js
+++ b/components/modules/quickSurvey/QuickSurvey.js
@@ -16,7 +16,7 @@ import { updateVehicle } from '../../../actions/VehicleAction';
 import { updatePassenger } from '../../../actions/PassengerAction';
 import { updateRoad } from '../../../actions/RoadAction';
 
-import NumberButtonSelector from '../../buttonSelectors/NumberButtonSelector';
+import NumberButtonSelectorQuickSurvey from '../../buttonSelectors/NumberButtonSelectorQuickSurvey';
 import MultiButtonSelectorQuickSurvey from '../../buttonSelectors/MultiButtonSelectorQuickSurvey';
 import { styles } from './QuickSurvey.style';
 
@@ -329,7 +329,7 @@ class QuickSurvey extends Component {
               <TopNavigation title='Quick Survey' alignment='center' leftControl={this.props.BackAction()} />
               <ScrollView style={{ flex: 1 }}>
                 <SafeAreaView style={styles.questionContainer}>
-                  <NumberButtonSelector
+                  <NumberButtonSelectorQuickSurvey
                     title="Number of vehicles involved"
                     submitFunction={changeVehicle}
                     reducerName="quickquizReducer"
@@ -337,7 +337,7 @@ class QuickSurvey extends Component {
                   />
                 </SafeAreaView>
                 <SafeAreaView style={styles.questionContainer}>
-                  <NumberButtonSelector
+                  <NumberButtonSelectorQuickSurvey
                     title="Number of non-motorists involved"
                     submitFunction={changeNonmotorists}
                     reducerName="quickquizReducer"
@@ -345,7 +345,7 @@ class QuickSurvey extends Component {
                   />
                 </SafeAreaView>
                 {/*<SafeAreaView style = {styles.questionContainer}>
-                <NumberButtonSelector
+                <NumberButtonSelectorQuickSurvey
                   title="Number of fatalities"
                   submitFunction = {changeFatality}
                   reducerName = "quickquizReducer"
@@ -353,7 +353,7 @@ class QuickSurvey extends Component {
                 />
               </SafeAreaView>
               <SafeAreaView style = {styles.questionContainer}>
-                <NumberButtonSelector
+                <NumberButtonSelectorQuickSurvey
                   title="Number of non-fatal injuries"
                   submitFunction = {changeNonFatalInjury}
                   reducerName = "quickquizReducer"

--- a/containers/AutoComponentContainer.js
+++ b/containers/AutoComponentContainer.js
@@ -9,7 +9,7 @@ import DropDownSingleSelect from '../components/dropdowns/DropDownSingleSelect';
 import OpenTextField from '../components/textFields/OpenTextField';
 import DropDownMultiSelect from '../components/dropdowns/DropDownMultiSelect';
 import LargeTextField from '../components/textFields/LargeTextField';
-
+import NumberButtonSelector from '../components/buttonSelectors/NumberButtonSelector';
 import {questions} from '../data/questions';
 
 class AutoComponentContainer extends Component {
@@ -60,6 +60,13 @@ class AutoComponentContainer extends Component {
         case 'autoCompleteDropdown':
           return (
             <AutoCompleteDropDown
+              data={question}
+              key={question.id}
+            />
+          )
+        case 'numberButton':
+          return (
+            <NumberButtonSelector
               data={question}
               key={question.id}
             />


### PR DESCRIPTION
# Description

There are multiple fields that require a numerical input. In the app's current state, most of those fields are text fields that allow the user to enter any value. To limit the validation requirements and likelihood that a person might mistype their input, the field should have suggested values. This PR changes the field to a `numberButtonSelector`, which is also used in the `QuickSurvey` when selecting the number of vehicles and non-motorists.

# Images

## Before
![image](https://user-images.githubusercontent.com/42981026/136673093-0ab47dc0-c636-48dd-803d-cd8570e73491.png)

## After
![image](https://user-images.githubusercontent.com/42981026/136673264-c5454629-1afa-4235-b6d7-5853bb732880.png)

# Testing
1. In `questions.js` find 'Enter the total auxiliary lanes'
2.  Change `answerType` form `openTextBox` to `numberButton`
3. Open the app
4. Start a new report
5. Add a vehicle
6. Click 'Confirm Changes'
7. Click on the vehicle icon
8. Navigate to 'Enter the total auxiliary lanes'
9. Options should be number buttons and a text field for numbers great than five
