### PR TITLE
[RUIN-147] Redirect from Quick Survey to Section Overview

### DIFF
--- a/components/modules/quickSurvey/QuickSurvey.js
+++ b/components/modules/quickSurvey/QuickSurvey.js
@@ -229,7 +229,7 @@ class QuickSurvey extends Component {
       // gets called when user clicks continue button
       const moveHome = () => {
         if (quiz.hasResponded){
-          navigation.navigate('Home', {edit: !this.state.loadedAutoSave});
+          navigation.navigate('Home', {edit: false});
           return
         }
         
@@ -237,7 +237,7 @@ class QuickSurvey extends Component {
         if (!this.state.loadedAutoSave) {
           dispatchAll();
         }
-        navigation.navigate('Home', { edit: !this.state.loadedAutoSave});
+        navigation.navigate('Home', { edit: false});
       }
 
       // filter out questions in questions.js with particular display


### PR DESCRIPTION
# Description

The current flow of the app goes from the quick survey to the edit sections page. This is confusing because the user just filled out the quick survey which populates the number of items in each section. Therefore it does not make sense to make the user confirm the number of items in each section before being able to edit the items. Now the user is redirected from the quick survey to the form edit page. If the user needs to change the number of items in any of the sections, the user can click on "Edit Sections".

# Images

_Don't know why the colors are off in the examples_

## Before
![deepin-screen-recorder_Select area_20211011165734](https://user-images.githubusercontent.com/42981026/136854789-90418dc0-48bf-4979-8049-9f389ff968f3.gif)

## After
![deepin-screen-recorder_Select area_20211011165433](https://user-images.githubusercontent.com/42981026/136854420-7fc749c7-3e30-455e-8fae-8af78bfb8804.gif)

# Testing

1. Open the app
2. Start a new report
3. Fill in random values
4. Click "Continue"
5. User should be directed to the page that allows form editing
   - The buttons at the top of the page should be "Export" and "Edit Sections"