### PR TITLE
[RUIN-100] Change order of export and edit buttons on home screen

### DIFF
--- a/components/home/Home.js
+++ b/components/home/Home.js
@@ -173,6 +173,15 @@ class Home extends Component {
             } else {
                 return (
                     <View style={styles.rightControlsContainer}>
+                        <Layout style={styles.rightControls}>
+                            <Pressable style={styles.rightControls} onPress = {() => {
+                              this.setState({edit: true})
+                            }}>
+                             <TopNavigationAction icon={editIcon}/>
+                             <Text style={styles.rightControlsText}>Edit Sections</Text>
+                           </Pressable>
+                         </Layout>
+
                          <Layout style={styles.rightControls}>
                            <Pressable style={styles.rightControls} onPress = {() =>
                            {navigation.navigate('FinalReport')}
@@ -181,16 +190,7 @@ class Home extends Component {
                              <Text style={styles.rightControlsText}>Export</Text>
                            </Pressable>
                          </Layout>
-                         <Layout
-                          style={styles.rightControls}
-                          >
-                            <Pressable style={styles.rightControls} onPress = {() => {
-                              this.setState({edit: true})
-                            }}>
-                             <TopNavigationAction icon={editIcon}/>
-                             <Text style={styles.rightControlsText}>Edit Sections</Text>
-                           </Pressable>
-                         </Layout>
+
                      </View>
                  )
             }


### PR DESCRIPTION
# Description 

This change switches the order of the export and edit buttons in the Section Overview view of the home screen. Now, the export button is on the right and the edit button is on the left, which is a more intuitive structure.

# Testing
1. Open the app and create a new report.
2. Click continue on the QuickSurvey screen.
3. Confirm that the buttons are in the right order.