### PR TITLE
[RUIN-94] Create a Continue Report Button on the welcome screen

### DIFF
--- a/components/home/Welcome.js
+++ b/components/home/Welcome.js
@@ -33,6 +33,7 @@ class Welcome extends Component {
         filePathSelected: false,
         selectedFile: {label: "", value: ""}
       };
+      this.unfinishedReportsPresent = false
     }
 
     async componentDidMount() {
@@ -46,16 +47,19 @@ class Welcome extends Component {
       this.props.resetMap();
       this.props.resetPhoto();
       await this.stateManager.getFilePaths();
-      this.checkAutoSavedSession();
+      this.unfinishedReportsAbsent = this.stateManager.filePaths.length == 0
+      console.log(this.stateManager.filePaths);
+      console.log(this.stateManager.filePaths.length == 0)
+//      this.checkAutoSavedSession();
       this.setState({ loading: false });
     }
 
     checkAutoSavedSession(){
         if (this.stateManager.filePaths != null) {
-            this.setState({autoSavedSession : true, autoSavedSessionDialogBoxVisible : true});
+            this.setState({autoSavedSession : true, filePickerDialogBoxVisible: true});
             console.log('Detect unfinished reports!');
         } else {
-            this.setState({ autoSavedSession: false, autoSavedSessionDialogBoxVisible: false });
+            this.setState({ autoSavedSession: false, filePickerDialogBoxVisible: false });
             console.log('No unfinished report!');
         }
     }
@@ -94,7 +98,13 @@ class Welcome extends Component {
                   <TouchableOpacity style={styles.styledButton} activeOpacity = { .7 } onPress={() => navigateTo('Survey')}>
                       <Text style={styles.btnText}>Start New Report</Text>
                   </TouchableOpacity>
+
+                  <TouchableOpacity style={this.unfinishedReportsAbsent ? styles.styledButtonDisabled : styles.styledButtonEnabled} activeOpacity = { .7 } onPress={() => this.checkAutoSavedSession()}
+                  disabled={this.unfinishedReportsAbsent}>
+                        <Text style={styles.btnText}>Continue Report</Text>
+                  </TouchableOpacity>
                 </View>
+
                 {this.state.displayOutputTest && <Button style={styles.styledButton} onPress={() => navigateTo('OutputPDFTest')}>Test Output PDF</Button>}
               </Layout>
               <Layout style={styles.bottomBar}>
@@ -103,25 +113,6 @@ class Welcome extends Component {
                   {"Built by students at Olin College of Engineering in partnership with the Volpe Center and Santos Family Foundation"}
                 </Text>
               </Layout>
-
-              <MaterialDialog
-                title={"Resume Unfinished Session?"}
-                visible={this.state.autoSavedSessionDialogBoxVisible}
-                okLabel='YES'
-                cancelLabel = 'NO'
-                onCancel={() => {
-                  this.setState({ autoSavedSession: false, autoSavedSessionDialogBoxVisible: false });
-                }}
-                onOk={() => {
-                  this.setState({ autoSavedSession: true,
-                                  autoSavedSessionDialogBoxVisible: false,
-                                  filePickerDialogBoxVisible: true });
-                }}
-              >
-                <Text style={material.subheading}>
-                  Your last session was interrupted unexpectedly. Would you like to resume from where you left off?
-                </Text>
-              </MaterialDialog>
 
               <SinglePickerMaterialDialog
                     title={"Choose the unfinished report you want to continue"}

--- a/components/home/Welcome.style.js
+++ b/components/home/Welcome.style.js
@@ -25,6 +25,30 @@ export const styles = StyleSheet.create({
       borderWidth: 1,
       borderColor: '#fff'
     },
+    styledButtonEnabled: {
+        margin: 10,
+        marginTop:10,
+        paddingTop:15,
+        paddingBottom:15,
+        paddingLeft:40,
+        paddingRight:40,
+        backgroundColor:'#3266FF',
+        borderRadius:10,
+        borderWidth: 1,
+        borderColor: '#fff'
+    },
+    styledButtonDisabled: {
+        backgroundColor: '#999999',
+        margin: 10,
+        marginTop:10,
+        paddingTop:15,
+        paddingBottom:15,
+        paddingLeft:40,
+        paddingRight:40,
+        borderRadius:10,
+        borderWidth: 1,
+        borderColor: '#fff'
+    },
     btnText: {
         fontSize: 20,
         color: "#FFFFFF",


### PR DESCRIPTION
# Description

This change modifies the welcome screen to add a continue report button below the start report button. When the welcome screen loads, the app checks to see if there are any unfinished reports, and if not, disables the button. If the button is enabled and the user clicks on the button, a dialog pops up allowing the user to select a specific in-progress report. This flow allows the user more control over whether they want to start a new report or continue an unfinished report.

# Testing
1. In the AVD manager, pick one virtual device and wipe its disk by clicking on the dropdown arrow and selecting "Wipe disk".
2. Run the app on the device.
3. Open the app.
4. The Continue Report button should be disabled.
5. Start a new report. Click on a few random buttons.
6. Click continue.
7. Close the app.
8. Reopen the app.
9. The Continue Report button should now be enabled.
10. Select the report you just saved. It should reload successfully.