### PR TITLE
Fix/casey j may/navigation back to welcome

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/screens/finalReportScreen.js
+++ b/screens/finalReportScreen.js
@@ -1,13 +1,31 @@
 import React from 'react';
-import { Icon, TopNavigationAction } from '@ui-kitten/components';
 import FinalReport from '../components/FinalReport';
+import { View, ScrollView, Keyboard, BackHandler, Pressable } from 'react-native';
+import { styles } from '../components/home/Home.style';
+import { TopNavigation, TopNavigationAction, Text, Card, CardHeader, Layout, Icon } from '@ui-kitten/components';
 
 export const FinalReportScreen = ({navigation}) => {
+
+    const finalReportIcon = (style) => (
+                <Icon {...style} name='file-text' fill="white" />
+            );
     return(
+        <>
         <FinalReport
             navigation = {navigation}
             BackAction = {()=> <TopNavigationAction icon={(style) => <Icon {...style} name='arrow-back'/>}
                                                     onPress={() => navigation.goBack()}/>}
         />
+        <View style={styles.rightControlsContainer}>
+                                             <Layout style={styles.rightControls}>
+                                               <Pressable style={styles.rightControls} onPress = {() =>
+                                               {navigation.navigate('Welcome')}
+                                               }>
+                                                 <TopNavigationAction icon={finalReportIcon}/>
+                                                 <Text style={styles.rightControlsText}>Back to New Report</Text>
+                                               </Pressable>
+                                             </Layout>
+        </View>
+        </>
     );
 };


### PR DESCRIPTION
Ignore distribution URL per usual

# Description
Added a button (unstyled) to the final report page that allows you to return to the welcome screen. It is my understanding that this clears the data properly automatically, but this could use some testing because it is VERY DIFFICULT to test edge cases on this one. Don't worry about the look, this change won't be merged until after the UI Toolkit change.

# Testing 
1. Checkout to this branch
2. Launch the app, navigate straight through. Try and select some question options along the way in random order, to see if there are any errors related to maintaining irrelevant data.
3. Once you reach the export page, click the "Back to New Report" button in the  bottom left. Don't worry about the gross look.
4. If it returns you to the welcome page, it's at least half functioning. Try and navigate partially through the app again. See if anything is off, this is tough to outline edge cases for, but I'm concerned many exist.