### PR TITLE
[RUIN-202] Re-order unfinished reports so most recent reports show up at the top

### DIFF
--- a/utils/backgroundSave.js
+++ b/utils/backgroundSave.js
@@ -27,7 +27,7 @@ export class backgroundSave {
         await this.RNFS.readdir(this.RNFS.DocumentDirectoryPath).then( files => {
             for (const file of files) {
                 if (file.includes('CrashReport') && file.includes('.json')) {
-                    this.filePaths.push(file);
+                    this.filePaths.unshift(file);
                 }
             }
         });


### PR DESCRIPTION
# Description

This change re-orders the order of the unfinished reports in the file picker when the user chooses to continue a report so that the most recent reports are at the top. This makes it easier for the user to find the most recent reports because they no longer need to scroll all the way down to the bottom.

# Testing
1. Open app
2. Select continue report from the welcome screen
3. Confirm that the reports at the top are more recent than the ones at the bottom