### PR TITLE
[RUIN-239] Debug question dependencies

### DIFF
--- a/components/textFields/LargeTextField.js
+++ b/components/textFields/LargeTextField.js
@@ -103,7 +103,6 @@ const LargeTextField = (props) => {
     if (renderComponent){
         return(
         <Box>
-<<<<<<< HEAD
             <QuestionSection
              title={data.question}
              helperText={data.helperText}
@@ -116,16 +115,6 @@ const LargeTextField = (props) => {
                  value={value}
                  onChangeText={onTextChange}
                 />
-=======
-            <QuestionSection title={data.question} helperText={data.helperText} errorMessage='Maximum Character Limit Exceeded' isInvalid={isInvalid}>
-                <VStack>
-                    <TooltipView toolTip={data.tooltip} helperImg={data.helperImg}/>
-                    <TextArea
-                        placeholder="Place your text"
-                        value={value}
-                        onChangeText={onTextChange}/>
-                </VStack>
->>>>>>> fix/18chowdhary/fix-tooltip-images
             </QuestionSection>
         </Box>
         )

--- a/data/questions.js
+++ b/data/questions.js
@@ -6,7 +6,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "First Name of Person Involved",
-                    "id": "c3920dfd-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e63-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -16,7 +16,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Middle Initial of Person Involved",
-                    "id": "c3920dfe-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e64-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -26,7 +26,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Last Name of Person Involved",
-                    "id": "c3920dff-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e65-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -36,7 +36,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Date of Birth",
-                    "id": "c3920e00-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e66-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -48,7 +48,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 1",
-                    "id": "c3920e01-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e67-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -59,7 +59,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 2",
-                    "id": "c3920e02-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e68-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -69,7 +69,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "City/Town",
-                    "id": "c3920e03-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e69-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -79,7 +79,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "State",
-                    "id": "c3920e04-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e6a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -89,7 +89,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "ZIP Code",
-                    "id": "c3920e05-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e6b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -99,7 +99,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Phone Number",
-                    "id": "c3920e06-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e6c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -110,7 +110,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Sex",
-                    "id": "c3920e07-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e6d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -142,7 +142,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Driver License Jurisdiction",
-                    "id": "c3920e09-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e6f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -152,7 +152,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type",
-                    "id": "c3920e0a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e70-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -200,7 +200,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Name of Jurisdiction (ANSI Code)",
-                    "id": "c3920e0b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e71-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -211,18 +211,19 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "License Number",
-                    "id": "c3920e0c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e72-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "advancedOpenTextBox",
                     "display": [
                         "driver"
                     ],
                     "humanReadableId": "driver-licenseNum",
+                    "tooltip": "Scan the barcode on the back of the driver's license.",
                     "autoMethod": "driverIDCamera"
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Class",
-                    "id": "c3920e0d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e73-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -263,7 +264,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Commercial Driver License (CDL)",
-                    "id": "c3920e0e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e74-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -283,7 +284,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Endorsements",
-                    "id": "c3920e0f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e75-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -328,7 +329,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Restrictions",
-                    "id": "c3920e10-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e76-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -338,7 +339,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "3.0",
                     "question": "Driver License Restrictions",
-                    "id": "c3920e11-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e77-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -427,7 +428,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Alcohol Interlock Present?",
-                    "id": "c3920e12-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e78-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "numberButton",
                     "display": [
                         "driver"
@@ -451,7 +452,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Driver License Status",
-                    "id": "c3920e13-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e79-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -461,7 +462,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type Applicable for This Person",
-                    "id": "c3920e14-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e7a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -485,7 +486,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Status",
-                    "id": "c3920e15-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e7b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -537,7 +538,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Seating Position",
-                    "id": "c3920e17-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e7d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -619,7 +620,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Restraint Systems / Motorcycle Helmet Use",
-                    "id": "c3920e18-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e7e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -629,7 +630,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Restraint Systems in Use",
-                    "id": "c3920e19-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e7f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -713,7 +714,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Any Indication of Improper Use?",
-                    "id": "c3920e1a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e80-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -734,7 +735,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Air Bag Deployed?",
-                    "id": "c3920e1b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e81-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -776,7 +777,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Ejection?",
-                    "id": "c3920e1c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e82-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -808,7 +809,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Speeding-Related?",
-                    "id": "c3920e1d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e83-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -840,7 +841,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Driver Actions at Time of Crash",
-                    "id": "c3920e1e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e84-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -929,7 +930,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Violation Codes",
-                    "id": "c3920e1f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e85-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -951,7 +952,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Distracted By",
-                    "id": "c3920e20-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e86-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -961,7 +962,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Action",
-                    "id": "c3920e21-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e87-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -993,7 +994,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Source",
-                    "id": "c3920e22-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e88-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -1002,23 +1003,28 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-distractedAction",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e87-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-distractedAction",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e87-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-distractedAction",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e87-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-distractedAction",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e87-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-distractedAction",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e87-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1063,7 +1069,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Condition at Time of the Crash",
-                    "id": "c3920e23-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e89-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -1120,7 +1126,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Incident Responder?",
-                    "id": "c3920e25-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e8b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -1164,7 +1170,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Status",
-                    "id": "c3920e26-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e8c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1197,7 +1203,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Area",
-                    "id": "c3920e27-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e8d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -1207,23 +1213,28 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1268,7 +1279,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Injury Diagnosis",
-                    "id": "c3920e28-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e8e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "largeTextField",
                     "display": [
                         "driver"
@@ -1278,30 +1289,35 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Severity",
-                    "id": "c3920e29-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e8f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1310,23 +1326,28 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1359,7 +1380,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Transported to First Medical Facility By",
-                    "id": "c3920e2a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e90-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -1368,30 +1389,35 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Source of Transport to First Medical Facility",
-                    "id": "c3920e2b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e91-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1400,23 +1426,28 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1449,7 +1480,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "EMS Response Agency Identifier",
-                    "id": "c3920e2c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e92-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -1458,30 +1489,35 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "EMS Response Run Number",
-                    "id": "c3920e2d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e93-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -1490,30 +1526,35 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Medical Facility Receiving Patient",
-                    "id": "c3920e2e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e94-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "driver"
@@ -1522,23 +1563,28 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-injuryStatus",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 }
@@ -1553,7 +1599,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "CMV License Status and Compliance with CDL Endorsements",
-                    "id": "c3920e30-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e96-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "driver"
@@ -1561,15 +1607,51 @@ export const questions = {
                     "humanReadableId": "driver-CMV",
                     "questionDependency": [
                         {
-                            "dependencyName": "sM5HGjcV",
-                            "dependencyOptionCode": "1"
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "CMV License Status",
-                    "id": "c3920e31-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e97-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -1577,8 +1659,44 @@ export const questions = {
                     "humanReadableId": "driver-CMVStatus",
                     "questionDependency": [
                         {
-                            "dependencyName": "sM5HGjcV",
-                            "dependencyOptionCode": "1"
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1627,7 +1745,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Compliance with CDL Endorsement(s)",
-                    "id": "c3920e32-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e98-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "driver"
@@ -1635,8 +1753,44 @@ export const questions = {
                     "humanReadableId": "driver-complianceCDL",
                     "questionDependency": [
                         {
-                            "dependencyName": "sM5HGjcV",
-                            "dependencyOptionCode": "1"
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1673,7 +1827,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Law Enforcement Suspects Alcohol Use",
-                    "id": "c3920e34-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e9a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1697,7 +1851,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Alcohol Test Status",
-                    "id": "c3920e35-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e9b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1706,15 +1860,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1739,7 +1896,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type of Alcohol Test",
-                    "id": "c3920e36-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e9c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1748,15 +1905,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1785,7 +1945,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "BAC Test Result",
-                    "id": "c3920e37-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e9d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBoxWithSelection",
                     "display": [
                         "driver"
@@ -1794,15 +1954,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedAlcohol",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9a-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1831,7 +1994,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Law Enforcement Suspects Drug Use",
-                    "id": "c3920e39-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791e9f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1855,7 +2018,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Drug Test Status",
-                    "id": "c3920e3a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ea0-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1864,15 +2027,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1897,7 +2063,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type of Drug Test",
-                    "id": "c3920e3b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ea1-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "driver"
@@ -1906,15 +2072,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -1943,7 +2112,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Drug Test Result",
-                    "id": "c3920e3c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ea2-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "driver"
@@ -1953,15 +2122,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "driver-suspectedDrug",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791e9f-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -2013,12 +2185,362 @@ export const questions = {
             ]
         },
         {
+            "sectionTitle": "Fataiity-Related Information",
+            "questions": [
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Attempted Avoidance Maneuver",
+                    "id": "11791ea4-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-attemptedAvoidance",
+                    "tooltip": "Movements/actions taken by the driver after the driver realizes there is an impending danger.",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "No Driver Present/Unknown if Driver Present",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Accelerating",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Accelerating and Steering Left",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Accelerating and Steering Right",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Braking and Steering Left",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Braking and Steering Right",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Braking (Lockup)",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Braking (Lockup Unknown)",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Braking (No Lockup)",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "No Avoidance Maneuver",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Releasing Brakes",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Steering Left",
+                            "id": "11.0"
+                        },
+                        {
+                            "name": "Steering Right",
+                            "id": "12.0"
+                        },
+                        {
+                            "name": "Other Actions",
+                            "id": "13.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "14.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Detailed Alcohol Test Information",
+                    "id": "11791ea5-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-delatedAlcohol",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Alcohol Test Type",
+                    "id": "11791ea6-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-fatalAlcoholTest",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Breath Test (AC)",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Blood",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Blood Clot",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Blood Plasma/Serum",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Liver",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Preliminary Breath Test (PBT)",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Urine",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Vitreous",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Other Test Type",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Unknown Test Type",
+                            "id": "11.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Alcohol Test Result",
+                    "id": "11791ea7-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBoxWithSelection",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-fatalAlcoholResult",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "0.94 or Greater",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Test Not Given",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "AC Test Performed, Results Unknown",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Positive Reading with No Actual Value",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "4.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Detailed Drug Test Information",
+                    "id": "11791ea8-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-deltailedDrug",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Drug Test Type",
+                    "id": "11791ea9-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-fatalDrugTest",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Blood",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Both Blood and Urine",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unknown Test Type",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Urine",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Other Test Type",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "6.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Result of Drug Test",
+                    "id": "11791eaa-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "driver"
+                    ],
+                    "humanReadableId": "driver-fatalDrugResult",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "driver-injuryStatus",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791e8c-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Tested No Drugs Found/Negative",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Narcotic",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Depressant",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Simulant",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Hallucinogen",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Cannabinoid",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Phencyclidine (PCP)",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Anabolic Steroid",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Inhalant",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Other Drug",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Tested for Drugs, Results Unknown",
+                            "id": "11.0"
+                        },
+                        {
+                            "name": "Tested for Drugs, Drugs Found, Type Unknown/Positive",
+                            "id": "12.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "13.0"
+                        }
+                    ]
+                }
+            ],
+            "display": [
+                "driver"
+            ]
+        },
+        {
             "sectionTitle": "Vehicle Owner Information",
             "questions": [
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "First Name",
-                    "id": "c3920e46-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eac-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2028,7 +2550,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Middle Initial",
-                    "id": "c3920e47-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ead-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2038,7 +2560,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Last Name",
-                    "id": "c3920e48-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eae-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2048,7 +2570,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 1",
-                    "id": "c3920e49-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eaf-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2058,7 +2580,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 2",
-                    "id": "c3920e4a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb0-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2068,7 +2590,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "City/Town",
-                    "id": "c3920e4b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb1-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2078,7 +2600,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "State",
-                    "id": "c3920e4c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb2-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2088,7 +2610,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "ZIP Code",
-                    "id": "c3920e4d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb3-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2098,7 +2620,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Insurance Information",
-                    "id": "c3920e4e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb4-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2108,7 +2630,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Insurance Company Name",
-                    "id": "c3920e4f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb5-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBoxWithSelection",
                     "display": [
                         "vehicle"
@@ -2124,7 +2646,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "NAIC #",
-                    "id": "c3920e50-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb6-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBoxWithSelection",
                     "display": [
                         "vehicle"
@@ -2140,7 +2662,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Policy #",
-                    "id": "c3920e51-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eb7-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBoxWithSelection",
                     "display": [
                         "vehicle"
@@ -2164,19 +2686,18 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Vehicle Identification Number (VIN)",
-                    "id": "c3920e53-47ba-11ec-a7dd-c10f8e2a7b83",
-                    "answerType": "advancedOpenTextBox",
+                    "id": "11791eb9-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
                     "display": [
                         "vehicle"
                     ],
                     "humanReadableId": "vehicle-VIN",
-                    "tooltip": "The VIN can often be found on the lower-left corner of the dashboard, in front of the steering wheel.",
-                    "autoMethod": "VINCamera"
+                    "tooltip": "The VIN can often be found on the lower-left corner of the dashboard, in front of the steering wheel."
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Motor Vehicle Unit Type ",
-                    "id": "c3920e54-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eba-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2200,7 +2721,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Registration State and Year",
-                    "id": "c3920e55-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ebb-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2211,7 +2732,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Identifier",
-                    "id": "c3920e56-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ebc-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2223,7 +2744,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Year of Motor Vehicle Registration",
-                    "id": "c3920e57-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ebd-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2234,18 +2755,17 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle License Plate Number",
-                    "id": "c3920e58-47ba-11ec-a7dd-c10f8e2a7b83",
-                    "answerType": "advancedOpenTextBox",
+                    "id": "11791ebe-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
                     "display": [
                         "vehicle"
                     ],
-                    "humanReadableId": "vehicle-licensePlate",
-                    "autoMethod": "plateCamera"
+                    "humanReadableId": "vehicle-licensePlate"
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Make",
-                    "id": "c3920e59-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ebf-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2255,7 +2775,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Model",
-                    "id": "c3920e5a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec0-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2265,7 +2785,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Model Year",
-                    "id": "c3920e5b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec1-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2276,7 +2796,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Body Type Category",
-                    "id": "c3920e5c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec2-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2286,7 +2806,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Body Type Category",
-                    "id": "c3920e5d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec3-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -2423,7 +2943,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Vehicle Size",
-                    "id": "c3920e5e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec4-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2448,7 +2968,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Number of Trailing Units",
-                    "id": "c3920e5f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec5-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2477,7 +2997,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Did this motor vehicle display a hazardous materials (HM) placard?",
-                    "id": "c3920e60-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec6-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2497,7 +3017,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Total Occupants in Motor Vehicle",
-                    "id": "c3920e61-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec7-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "numberButton",
                     "display": [
                         "vehicle"
@@ -2507,7 +3027,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Special Function of Motor Vehicle in Transport",
-                    "id": "c3920e62-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec8-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -2518,7 +3038,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Emergency Motor Vehicle Use",
-                    "id": "c3920e63-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ec9-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -2554,7 +3074,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Posted/ Statutory Speed Limit",
-                    "id": "c3920e64-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eca-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "vehicle"
@@ -2573,7 +3093,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Direction of Travel Before Crash",
-                    "id": "c3920e66-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ecc-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2610,7 +3130,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Trafficway Description",
-                    "id": "c3920e67-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ecd-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2620,7 +3140,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Travel Directions",
-                    "id": "c3920e68-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ece-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2640,7 +3160,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Divided?",
-                    "id": "c3920e69-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ecf-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -2676,7 +3196,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Barrier Type",
-                    "id": "c3920e6a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed0-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2712,7 +3232,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "HOV/HOT Lanes",
-                    "id": "c3920e6b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed1-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -2737,7 +3257,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Crash Related to HOV/HOT Lane?",
-                    "id": "c3920e6c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed2-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2746,15 +3266,18 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-hovHotLanes",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ed1-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-hovHotLanes",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ed1-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-hovHotLanes",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ed1-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -2771,7 +3294,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Total Lanes in Roadway",
-                    "id": "c3920e6d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed3-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2781,7 +3304,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Enter the total through lanes, excluding auxiliary lanes.",
-                    "id": "c3920e6e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed4-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "numberButton",
                     "display": [
                         "vehicle"
@@ -2792,7 +3315,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Enter the total auxiliary lanes",
-                    "id": "c3920e6f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed5-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "numberButton",
                     "display": [
                         "vehicle"
@@ -2803,7 +3326,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Roadway Alignment and Grade",
-                    "id": "c3920e70-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed6-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2813,7 +3336,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Horizontal Alignment",
-                    "id": "c3920e71-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed7-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2837,7 +3360,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Grade",
-                    "id": "c3920e72-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed8-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -2869,7 +3392,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Traffic Control Device (TCD) Type",
-                    "id": "c3920e73-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ed9-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -2879,7 +3402,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "TCD Type(s)",
-                    "id": "c3920e74-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eda-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "vehicle"
@@ -3004,7 +3527,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Are any Inoperative or Missing?",
-                    "id": "c3920e75-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791edb-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "vehicle"
@@ -3014,115 +3537,143 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "6.0"
+                            "dependencyOptionCode": "6.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "7.0"
+                            "dependencyOptionCode": "7.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "8.0"
+                            "dependencyOptionCode": "8.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "9.0"
+                            "dependencyOptionCode": "9.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "10.0"
+                            "dependencyOptionCode": "10.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "11.0"
+                            "dependencyOptionCode": "11.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "12.0"
+                            "dependencyOptionCode": "12.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "13.0"
+                            "dependencyOptionCode": "13.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "14.0"
+                            "dependencyOptionCode": "14.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "15.0"
+                            "dependencyOptionCode": "15.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "16.0"
+                            "dependencyOptionCode": "16.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "17.0"
+                            "dependencyOptionCode": "17.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "18.0"
+                            "dependencyOptionCode": "18.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "19.0"
+                            "dependencyOptionCode": "19.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "20.0"
+                            "dependencyOptionCode": "20.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "21.0"
+                            "dependencyOptionCode": "21.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "22.0"
+                            "dependencyOptionCode": "22.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "23.0"
+                            "dependencyOptionCode": "23.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "24.0"
+                            "dependencyOptionCode": "24.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "25.0"
+                            "dependencyOptionCode": "25.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "26.0"
+                            "dependencyOptionCode": "26.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-TCDTypes",
-                            "dependencyOptionCode": "27.0"
+                            "dependencyOptionCode": "27.0",
+                            "dependencyUuid": "11791eda-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -3251,7 +3802,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Motor Vehicle Maneuver/Action",
-                    "id": "c3920e77-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791edd-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -3323,7 +3874,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Vehicle Damage",
-                    "id": "c3920e78-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ede-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -3333,7 +3884,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Initial Point of Contact",
-                    "id": "c3920e79-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791edf-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -3419,7 +3970,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "13.0",
                     "question": "Location of Damage Area(s)",
-                    "id": "c3920e7a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee0-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "vehicle"
@@ -3430,75 +3981,93 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "6.0"
+                            "dependencyOptionCode": "6.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "7.0"
+                            "dependencyOptionCode": "7.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "8.0"
+                            "dependencyOptionCode": "8.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "9.0"
+                            "dependencyOptionCode": "9.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "10.0"
+                            "dependencyOptionCode": "10.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "11.0"
+                            "dependencyOptionCode": "11.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "12.0"
+                            "dependencyOptionCode": "12.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "13.0"
+                            "dependencyOptionCode": "13.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "14.0"
+                            "dependencyOptionCode": "14.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "15.0"
+                            "dependencyOptionCode": "15.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "16.0"
+                            "dependencyOptionCode": "16.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "17.0"
+                            "dependencyOptionCode": "17.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -3575,7 +4144,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Resulting Extent of Damage",
-                    "id": "c3920e7b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee1-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -3585,75 +4154,93 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "6.0"
+                            "dependencyOptionCode": "6.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "7.0"
+                            "dependencyOptionCode": "7.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "8.0"
+                            "dependencyOptionCode": "8.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "9.0"
+                            "dependencyOptionCode": "9.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "10.0"
+                            "dependencyOptionCode": "10.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "11.0"
+                            "dependencyOptionCode": "11.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "12.0"
+                            "dependencyOptionCode": "12.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "13.0"
+                            "dependencyOptionCode": "13.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "14.0"
+                            "dependencyOptionCode": "14.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "15.0"
+                            "dependencyOptionCode": "15.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "16.0"
+                            "dependencyOptionCode": "16.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "vehicle-initialPointContact",
-                            "dependencyOptionCode": "17.0"
+                            "dependencyOptionCode": "17.0",
+                            "dependencyUuid": "11791edf-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -3682,7 +4269,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Sequence of Events",
-                    "id": "c3920e7c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee2-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "vehicle"
@@ -3900,7 +4487,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Most Harmful Event for this Motor Vehicle",
-                    "id": "c3920e7d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee3-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -4076,7 +4663,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Hit and Run",
-                    "id": "c3920e7e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee4-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -4097,7 +4684,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Towed Due to Disabling Damage",
-                    "id": "c3920e7f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee5-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -4122,7 +4709,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Contributing Circumstances, Motor Vehicle",
-                    "id": "c3920e80-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee6-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -4199,7 +4786,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Motor Vehicle Automated Driving System(s)",
-                    "id": "c3920e81-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee7-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "vehicle"
@@ -4209,7 +4796,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Automated System(s) in Vehicle",
-                    "id": "c3920e82-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee8-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -4233,7 +4820,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "5.0",
                     "question": "Automated System Levels in Vehicle",
-                    "id": "c3920e83-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791ee9-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "vehicle"
@@ -4245,7 +4832,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-automatedSystems",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ee8-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -4286,7 +4874,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "5.0",
                     "question": "Automated System Levels Engaged at Time of Crash",
-                    "id": "c3920e84-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791eea-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "vehicle"
@@ -4296,7 +4884,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "vehicle-automatedSystems",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ee8-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -4340,12 +4929,1767 @@ export const questions = {
             ]
         },
         {
+            "sectionTitle": "Large Vehicles and Hazardous Material Related Information",
+            "questions": [
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Trailer License Plate Number",
+                    "id": "11791eec-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-trailerLicensePlate",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791eed-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "advancedOpenTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerLicense",
+                    "helperText": "License Plate 1",
+                    "autoMethod": "plateCamera",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791eee-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "advancedOpenTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-secondTrailerLicense",
+                    "helperText": "License Plate 2",
+                    "autoMethod": "plateCamera",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791eef-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "advancedOpenTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerLicense",
+                    "helperText": "License Plate 3",
+                    "autoMethod": "plateCamera",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Trailer VIN(s)",
+                    "id": "11791ef0-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-trailerVINs",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791ef1-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerVin",
+                    "helperText": "VIN 1",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791ef2-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-secondTrailerVin",
+                    "helperText": "VIN 2",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791ef3-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerVin",
+                    "helperText": "VIN 3",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Trailer Make(s)",
+                    "id": "11791ef4-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-trailerMakes",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791ef5-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerMake",
+                    "helperText": "Make 1",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791ef6-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-secondTrailerMake",
+                    "helperText": "Make 2",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791ef7-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerMake",
+                    "helperText": "Make 3",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Trailer Model(s)",
+                    "id": "11791ef8-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-trailerModels",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791ef9-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerModel",
+                    "helperText": "Model 1",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791efa-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehile-secondTrailerModel",
+                    "helperText": "Model 2",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791efb-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerModel",
+                    "helperText": "Model 3",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Trailer Model Year(s)",
+                    "id": "11791efc-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-trailerModelYears",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791efd-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerModelYear",
+                    "helperText": "Year 1",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791efe-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-secondTrailerModelYear",
+                    "helperText": "Year 2",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791eff-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerModelYear",
+                    "helperText": "Year 3",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Total Number of Axles",
+                    "id": "11791f00-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-numAxles",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Truck Tractor",
+                    "id": "11791f01-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-truckAxles",
+                    "helperText": "Number of axles",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "First Trailer Behind Tractor",
+                    "id": "11791f02-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-firstTrailerAxles",
+                    "helperText": "Number of axles",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Second Trailer Behind Tractor",
+                    "id": "11791f03-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-secondTrailerAxles",
+                    "helperText": "Number of axles",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Third Trailer Behind Tractor",
+                    "id": "11791f04-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-thirdTrailerAxles",
+                    "helperText": "Number of axles",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier Identification",
+                    "id": "11791f05-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-motorIdentification",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Identification Type",
+                    "id": "11791f06-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-identificationType",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "US DOT Number",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "State Number",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Not Applicable",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unknown/Unable to Determine",
+                            "id": "3.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Country/State Code",
+                    "id": "11791f07-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-countryStateCode",
+                    "tooltip": "Non-US Country Code (e.g. Mexico or Canada) US State Code",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Identification Number",
+                    "id": "11791f08-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-identificationNum",
+                    "tooltip": "US DOT Number - up to 7 digits If not a US DOT Number, include State issued Identification Number and State",
+                    "helperImg": "../image/determine_responsible_carrier.png",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier Name",
+                    "id": "11791f09-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierName",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier Street Address",
+                    "id": "11791f0a-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierStreetAddress",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier City/Town",
+                    "id": "11791f0b-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierCityTown",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier State",
+                    "id": "11791f0c-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierState",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Motor Carrier ZIP Code",
+                    "id": "11791f0d-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierZIP",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Type of Carrier",
+                    "id": "11791f0e-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-carrierType",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Interstate Carrier",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Intrastate Carrier",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Not in Commerce/Government",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Not in Commerce/Other Truck or Bus",
+                            "id": "3.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Vehicle Configuration Information",
+                    "id": "11791f0f-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-configurationInfo",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Vehicle Configuration",
+                    "id": "11791f10-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-configuration",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Vehicle 10,000 lbs. or less placarded for hazardous materials",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Bus/Large Van (seats for 9-15 occupants, including driver)",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Bus (seats more than 15 occupants, including driver)",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Single-Unit Truck (2-axle and GVWR > 10,000 lbs.)",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Single-Unit Truck (3 or more axles)",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Truck Pulling Trailer(s)",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Truck Tractor (Bobtail)",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Truck Tractor/Semi-Trailer",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Truck Tractor/Double",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Truck Tractor/Triple",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Truck More Than 10,000 lbs., cannot classify",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "11.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Special Sizing",
+                    "id": "11791f11-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-specialSizing",
+                    "helperText": "(choose up to 4)",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "No special sizing",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Over-height",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Over-length",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Over-weight",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Over-width",
+                            "id": "4.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Permitted?",
+                    "id": "11791f12-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-permitted",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-numTrailingUnits",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791ec5-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Non-Permitted Load",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Permitted Load",
+                            "id": "1.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Cargo Body Type",
+                    "id": "11791f13-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-cargoBodyType",
+                    "helperImg": "../image/cargo_body_types.png",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "vehicle-size",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791ec4-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "No Cargo Body (bobtail, light MV with hazardous materials [HM] placard, etc.)",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Bus",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Auto Transporter",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Cargo Tank",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Concrete Mixer",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Dump",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Flatbed",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Garbage/Refuse",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Grain/Chips/Gravel",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Intermodal Container Chassis",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Log",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Pole-Trailer",
+                            "id": "11.0"
+                        },
+                        {
+                            "name": "Van/Enclosed Box",
+                            "id": "12.0"
+                        },
+                        {
+                            "name": "Vehicle Towing Another Vehicle",
+                            "id": "13.0"
+                        },
+                        {
+                            "name": "Not Applicable (MV 10,000 lbs. or less, not displaying HM placard)",
+                            "id": "14.0"
+                        },
+                        {
+                            "name": "Other",
+                            "id": "15.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "16.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Hazardous Materials (Cargo Only)",
+                    "id": "11791f14-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-hazardousMaterialsCargo",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Hazardous Materials ID",
+                    "id": "11791f15-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-hazardousMaterialsID",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Hazardous Materials Class",
+                    "id": "11791f16-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-hazardousMaterialsClass",
+                    "helperImg": "../image/hazardous_materials_class.png",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Release of hazardous materials from a cargo compartment (e.g. trailer), cargo container (e.g. tank) or from a package?",
+                    "id": "11791f17-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "vehicle"
+                    ],
+                    "humanReadableId": "vehicle-releaseHazardousMaterials",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "vehicle-hazardousMaterials",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791ec6-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "No",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Yes",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Not Applicable",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unknown if Released",
+                            "id": "3.0"
+                        }
+                    ]
+                }
+            ],
+            "display": [
+                "vehicle"
+            ]
+        },
+        {
             "sectionTitle": "Personal Information Section",
             "questions": [
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "First Name of Person Involved",
-                    "id": "c3920eb3-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f19-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4355,7 +6699,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Middle Initial of Person Involved",
-                    "id": "c3920eb4-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4365,7 +6709,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Last Name of Person Involved",
-                    "id": "c3920eb5-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4375,7 +6719,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Date of Birth",
-                    "id": "c3920eb6-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4386,7 +6730,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 1",
-                    "id": "c3920eb7-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4397,7 +6741,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Street Address 2",
-                    "id": "c3920eb8-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4407,7 +6751,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "City/Town",
-                    "id": "c3920eb9-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f1f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4417,7 +6761,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "State",
-                    "id": "c3920eba-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f20-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4427,7 +6771,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "ZIP Code",
-                    "id": "c3920ebb-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f21-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4437,7 +6781,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Phone Number",
-                    "id": "c3920ebc-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f22-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4448,7 +6792,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Sex",
-                    "id": "c3920ebd-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f23-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -4468,21 +6812,19 @@ export const questions = {
                             "id": "2.0"
                         }
                     ]
-                },
-                {
-                    "numOptionsAllowed": "0.0",
-                    "question": "Crash-Related Information Section",
-                    "id": "c3920ebe-47ba-11ec-a7dd-c10f8e2a7b83",
-                    "answerType": "questionHeader",
-                    "display": [
-                        "nonmotorist"
-                    ],
-                    "humanReadableId": "nonmotorist-crashRelated"
-                },
+                }
+            ],
+            "display": [
+                "nonmotorist"
+            ]
+        },
+        {
+            "sectionTitle": "Crash-Related Information Section",
+            "questions": [
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Person Type",
-                    "id": "c3920ebf-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f25-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -4518,7 +6860,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Condition at Time of the Crash",
-                    "id": "c3920ec0-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f26-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "nonmotorist"
@@ -4567,7 +6909,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Unit Number of Motor Vehicle Striking Non-Motorist",
-                    "id": "c3920ec1-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f27-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -4578,7 +6920,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Non-Motorist Action/Circumstance Prior to Crash",
-                    "id": "c3920ec2-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f28-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "nonmotorist"
@@ -4588,7 +6930,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Action/Circumstance",
-                    "id": "c3920ec3-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f29-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -4644,7 +6986,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Origin/Destination",
-                    "id": "c3920ec4-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -4672,7 +7014,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Non-Motorist Contributing Action(s)/Circumstance(s)",
-                    "id": "c3920ec5-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "nonmotorist"
@@ -4741,7 +7083,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Non-Motorist Location at Time of Crash",
-                    "id": "c3920ec6-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -4830,7 +7172,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "5.0",
                     "question": "Non-Motorist Safety Equipment",
-                    "id": "c3920ec7-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "nonmotorist"
@@ -4875,7 +7217,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Initial Contact Point on Non-Motorist",
-                    "id": "c3920ec8-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -4907,7 +7249,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Distracted By",
-                    "id": "c3920ec9-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f2f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "nonmotorist"
@@ -4917,7 +7259,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Action",
-                    "id": "c3920eca-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f30-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -4945,7 +7287,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Source",
-                    "id": "c3920ecb-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f31-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -4954,19 +7296,23 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-distractedAction",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f30-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-distractedAction",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f30-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-distractedAction",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f30-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-distractedAction",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f30-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5019,7 +7365,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Incident Responder?",
-                    "id": "c3920ecd-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f33-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -5063,7 +7409,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Status",
-                    "id": "c3920ece-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f34-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5095,7 +7441,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Area",
-                    "id": "c3920ecf-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f35-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "nonmotorist"
@@ -5144,7 +7490,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Injury Diagnosis",
-                    "id": "c3920ed0-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f36-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "largeTextField",
                     "display": [
                         "nonmotorist"
@@ -5155,7 +7501,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Injury Severity",
-                    "id": "c3920ed1-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f37-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5191,7 +7537,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Transported to First Medical Facility By",
-                    "id": "c3920ed2-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f38-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "nonmotorist"
@@ -5200,34 +7546,40 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Source of Transport to First Medical Facility",
-                    "id": "c3920ed3-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f39-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5236,27 +7588,33 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5289,7 +7647,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "EMS Response Agency Identifier",
-                    "id": "c3920ed4-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f3a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -5298,34 +7656,40 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "EMS Response Run Number",
-                    "id": "c3920ed5-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f3b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -5334,34 +7698,40 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Medical Facility Receiving Patient",
-                    "id": "c3920ed6-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f3c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "nonmotorist"
@@ -5370,27 +7740,33 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "0.0"
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "1.0"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "2.0"
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "3.0"
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "4.0"
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         },
                         {
                             "dependencyName": "nonmotorist-injurySeverity",
-                            "dependencyOptionCode": "5.0"
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 }
@@ -5405,7 +7781,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Law Enforcement Suspects Alcohol Use",
-                    "id": "c3920ed8-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f3e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5429,7 +7805,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Alcohol Test Status",
-                    "id": "c3920ed9-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f3f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5438,7 +7814,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedAlcohol",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f3e-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5463,7 +7840,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type of Alcohol Test",
-                    "id": "c3920eda-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f40-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5472,7 +7849,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedAlcohol",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f3e-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5501,7 +7879,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "BAC Test Result",
-                    "id": "c3920edb-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f41-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBoxWithSelection",
                     "display": [
                         "nonmotorist"
@@ -5510,7 +7888,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedAlcohol",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f3e-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5539,7 +7918,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Law Enforcement Suspects Drug Use",
-                    "id": "c3920edd-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f43-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5563,7 +7942,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Drug Test Status",
-                    "id": "c3920ede-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f44-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5572,7 +7951,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedDrug",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f43-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5597,7 +7977,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type of Drug Test",
-                    "id": "c3920edf-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f45-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "nonmotorist"
@@ -5606,7 +7986,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedDrug",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f43-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5635,7 +8016,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Drug Test Result",
-                    "id": "c3920ee0-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f46-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "nonmotorist"
@@ -5644,7 +8025,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "nonmotorist-suspectedDrug",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f43-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -5696,12 +8078,282 @@ export const questions = {
             ]
         },
         {
+            "sectionTitle": "Fatality-Related Information",
+            "questions": [
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Detailed Alcohol Test Information",
+                    "id": "11791f48-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-detailedAlcohol",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Alcohol Test Type",
+                    "id": "11791f49-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-fatalAlcoholTest",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Breath Test (AC)",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Blood",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Blood Clot",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Blood Plasma/Serum",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Liver",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Preliminary Breath Test (PBT)",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Urine",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Vitreous",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Other Test Type",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Unknown Test Type",
+                            "id": "11.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Alcohol Test Result",
+                    "id": "11791f4a-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBoxWithSelection",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-fatalAlcoholREsult",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "0.94 or Greater",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Test Not Given",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "AC Test Performed, Results Unknown",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Positive Reading with No Actual Value",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "4.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Detailed Drug Test Information",
+                    "id": "11791f4b-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-detailedDrug",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Drug Test Type",
+                    "id": "11791f4c-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-fatalDrugTest",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Blood",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Both Blood and Urine",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unknown Test Type",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Urine",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Other Test Type",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "6.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Result of Drug Test",
+                    "id": "11791f4d-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "nonmotorist"
+                    ],
+                    "humanReadableId": "nonmotorist-fatalDrugResult",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "nonmotorist-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f37-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Test Not Given",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Tested No Drugs Found/Negative",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Narcotic",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Depressant",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Simulant",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Hallucinogen",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Cannabinoid",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Phencyclidine (PCP)",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Anabolic Steroid",
+                            "id": "8.0"
+                        },
+                        {
+                            "name": "Inhalant",
+                            "id": "9.0"
+                        },
+                        {
+                            "name": "Other Drug",
+                            "id": "10.0"
+                        },
+                        {
+                            "name": "Tested for Drugs, Results Unknown",
+                            "id": "11.0"
+                        },
+                        {
+                            "name": "Tested for Drugs, Drugs Found, Type Unknown/Positive",
+                            "id": "12.0"
+                        },
+                        {
+                            "name": "Unknown if Tested",
+                            "id": "13.0"
+                        }
+                    ]
+                }
+            ],
+            "display": [
+                "nonmotorist"
+            ]
+        },
+        {
             "sectionTitle": "Personal Information Section",
             "questions": [
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "First Name of Person Involved",
-                    "id": "c3920ee9-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f4f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "passenger"
@@ -5711,7 +8363,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Middle Initial of Person Involved",
-                    "id": "c3920eea-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f50-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "passenger"
@@ -5721,7 +8373,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Last Name of Person Involved",
-                    "id": "c3920eeb-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f51-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "passenger"
@@ -5731,7 +8383,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Date of Birth",
-                    "id": "c3920eec-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f52-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "passenger"
@@ -5742,7 +8394,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Sex",
-                    "id": "c3920eed-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f53-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "passenger"
@@ -5774,7 +8426,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Incident Responder?",
-                    "id": "c3920eef-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f55-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "passenger"
@@ -5818,7 +8470,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Seating Position",
-                    "id": "c3920ef0-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f56-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "passenger"
@@ -5900,7 +8552,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "nan",
                     "question": "Restraint Systems / Motorcycle Helmet Use",
-                    "id": "c3920ef1-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f57-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "passenger"
@@ -5910,7 +8562,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Restraint Systems in Use",
-                    "id": "c3920ef2-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f58-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "passenger"
@@ -5994,7 +8646,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Any Indication of Improper Use?",
-                    "id": "c3920ef3-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f59-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "passenger"
@@ -6015,7 +8667,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "4.0",
                     "question": "Air Bag Deployed?",
-                    "id": "c3920ef4-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f5a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "passenger"
@@ -6057,7 +8709,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Ejection?",
-                    "id": "c3920ef5-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f5b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "passenger"
@@ -6092,9 +8744,382 @@ export const questions = {
             ]
         },
         {
+            "sectionTitle": "Injury Related Information",
+            "questions": [
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Injury Status",
+                    "id": "11791f5d-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-injuryStatus",
+                    "tooltip": "Fatal Injury: an injury that results in death within 30 days after the motor vehicle crash in which the injury occured. If the person did not die at the scene, but died within 30 days of the motor vehicle crash in which the injury occured, the injury classification should be changed to Fatal Injury. \n\nSuspected Serious Injury: any injury other than fatal which results in one or more of the following: severe laceration reuslting in exposure of underlying tissues/muscles/organs or resulting in significant loss of blood; broken or distorted arm or leg; crush injuries; suspected skull, chest, or abdominal injury other than bruises or minor lacerations; significant burns (second and third degree burns over 10% or more of the body); unconsciousness when taken from crash scene; paralysis\n\nSuspected Minor Injury: any injury that is evident at the scene of the crash, other than fatal or serious injuries. Examples include lump on the head, abrasions, bruises, minor lacerations (cuts on the skin surface with minimal bleeding and no exposure of deeper tissue/muscle).\n\nPossible Injury: any injury reported or claimed which is not fatal, suspected  serious, or suspected minor. Examples include momentary loss of consciousness, claim of injury, limping, or complaint of pain or nausea. These are reported by the person or indicated by their behavior, but no wounds or injuries are readily evident.\n\nNo Apparent Injury: there is no reason to believe that the person received any bodily harm from the motor vehicle crash. There is no physical evidence of injury and the person does not report any change in normal function.\n",
+                    "answerOptions": [
+                        {
+                            "name": "Fatal Injury",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Suspected Serious Injury",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Suspected Minor Injury",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Possible Injury",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "No Apparent Injury",
+                            "id": "4.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Injury Area",
+                    "id": "11791f5e-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-injuryArea",
+                    "tooltip": "Select the primary or most obvious area of the person's body injured during the crash. This will be typically be indicated in a matrix or narrative in the EMS records or as a hospital discharge code (ICD-9-CM or ICD-10, if implemented) in the emergency department, hospital or insurance records.",
+                    "answerOptions": [
+                        {
+                            "name": "Head",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Face",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Neck",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Upper Extremity",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Thorax (chest)",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Spine",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Adnomen and Pelvis",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Lower Extremity",
+                            "id": "7.0"
+                        },
+                        {
+                            "name": "Unspecified",
+                            "id": "8.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Injury Diagnosis",
+                    "id": "11791f5f-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "largeTextField",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-injuryDiagnosis",
+                    "tooltip": "Describe the injury."
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Injury Severity",
+                    "id": "11791f60-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-injurySeverity",
+                    "answerOptions": [
+                        {
+                            "name": "Fatal",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Serious",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Moderate",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Minor",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "No Injury",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "5.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Transported to First Medical Facility By",
+                    "id": "11791f61-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-transported",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "1.0",
+                    "question": "Source of Transport to First Medical Facility",
+                    "id": "11791f62-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-transportSource",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ],
+                    "answerOptions": [
+                        {
+                            "name": "Not Transported",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "EMS Air",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "EMS Ground",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Law Enforcement",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Other",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "5.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "EMS Response Agency Identifier",
+                    "id": "11791f63-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-EMSIdentifier",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "EMS Response Run Number",
+                    "id": "11791f64-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-EMSRunNumber",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "0.0",
+                    "question": "Medical Facility Receiving Patient",
+                    "id": "11791f65-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "passenger"
+                    ],
+                    "humanReadableId": "passenger-medicalFacility",
+                    "questionDependency": [
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "0.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "2.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "3.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "4.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "passenger-injurySeverity",
+                            "dependencyOptionCode": "5.0",
+                            "dependencyUuid": "11791f60-52dc-11ec-9691-d109d8c8abd2"
+                        }
+                    ]
+                }
+            ],
+            "display": [
+                "passenger"
+            ]
+        },
+        {
             "numOptionsAllowed": "1.0",
             "question": "Ownership",
-            "id": "c3920f00-47ba-11ec-a7dd-c10f8e2a7b83",
+            "id": "11791f66-52dc-11ec-9691-d109d8c8abd2",
             "answerType": "multiButton",
             "display": [
                 "setup"
@@ -6115,7 +9140,7 @@ export const questions = {
         {
             "numOptionsAllowed": "1.0",
             "question": "Secondary Crash",
-            "id": "c3920f01-47ba-11ec-a7dd-c10f8e2a7b83",
+            "id": "11791f67-52dc-11ec-9691-d109d8c8abd2",
             "answerType": "multiButton",
             "display": [
                 "setup"
@@ -6136,7 +9161,7 @@ export const questions = {
         {
             "numOptionsAllowed": "1.0",
             "question": "Crash Severity",
-            "id": "c3920f02-47ba-11ec-a7dd-c10f8e2a7b83",
+            "id": "11791f68-52dc-11ec-9691-d109d8c8abd2",
             "answerType": "multiButton",
             "display": [
                 "setup"
@@ -6175,7 +9200,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Identifier",
-                    "id": "c3920f04-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -6186,7 +9211,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Agency Crash Identifier",
-                    "id": "c3920f05-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -6196,7 +9221,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Crash Severity",
-                    "id": "c3920f06-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -6232,7 +9257,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Description",
-                    "id": "c3920f07-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "largeTextField",
                     "display": [
                         "road"
@@ -6242,7 +9267,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Classification",
-                    "id": "c3920f08-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -6252,7 +9277,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Ownership",
-                    "id": "c3920f09-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f6f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -6273,7 +9298,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Characteristics",
-                    "id": "c3920f0a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f70-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -6299,7 +9324,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Secondary Crash",
-                    "id": "c3920f0b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f71-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -6320,7 +9345,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "School Bus-Related?",
-                    "id": "c3920f0c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f72-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -6345,7 +9370,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Date and Time",
-                    "id": "c3920f0d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f73-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -6355,7 +9380,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Date and Time (Valid Military Time)",
-                    "id": "c3920f0e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f74-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "advancedOpenTextBox",
                     "display": [
                         "road"
@@ -6368,7 +9393,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Time of Roadway Clearance (Valid Military Time)",
-                    "id": "c3920f0f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f75-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -6380,7 +9405,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash Location",
-                    "id": "c3920f10-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f76-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -6390,7 +9415,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Crash State",
-                    "id": "c3920f11-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f77-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -6626,7 +9651,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Crash County",
-                    "id": "c3920f12-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f78-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "countyDropDown",
                     "display": [
                         "road"
@@ -6636,14 +9661,15 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-state",
-                            "dependencyOptionCode": ""
+                            "dependencyOptionCode": "",
+                            "dependencyUuid": "11791f77-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 },
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Crash City/Place",
-                    "id": "c3920f13-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f79-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -6653,7 +9679,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Latitude",
-                    "id": "c3920f14-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f7a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "advancedOpenTextBox",
                     "display": [
                         "road"
@@ -6665,7 +9691,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Longitude",
-                    "id": "c3920f15-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f7b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "advancedOpenTextBox",
                     "display": [
                         "road"
@@ -6677,7 +9703,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "nan",
                     "question": "Nearest Street Address",
-                    "id": "c3920f16-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f7c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -6686,7 +9712,13 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-latitude",
-                            "dependencyOptionCode": "road-longitude"
+                            "dependencyOptionCode": "",
+                            "dependencyUuid": "11791f7a-52dc-11ec-9691-d109d8c8abd2"
+                        },
+                        {
+                            "dependencyName": "road-longitude",
+                            "dependencyOptionCode": "",
+                            "dependencyUuid": "11791f7b-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ]
                 }
@@ -6701,7 +9733,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "First Harmful Event Information",
-                    "id": "c3920f18-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f7e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -6711,7 +9743,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "First Harmful Event",
-                    "id": "c3920f19-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f7f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -6892,7 +9924,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Location of First Harmful Event Relative to the Trafficway",
-                    "id": "c3920f1a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f80-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -6949,7 +9981,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Manner of Crash/ Collision Impact",
-                    "id": "c3920f1b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f81-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7012,7 +10044,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Relation to Junction Section",
-                    "id": "c3920f1c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f82-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -7022,7 +10054,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Within Interchange Area?",
-                    "id": "c3920f1d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f83-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7047,7 +10079,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Specific Location",
-                    "id": "c3920f1e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f84-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7109,7 +10141,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Source of Information Section",
-                    "id": "c3920f1f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f85-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -7119,7 +10151,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Source of Information",
-                    "id": "c3920f20-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f86-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7140,7 +10172,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Law Enforcement Agency Identifier",
-                    "id": "c3920f21-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f87-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "openTextBox",
                     "display": [
                         "road"
@@ -7151,7 +10183,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Environment Conditions",
-                    "id": "c3920f22-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f88-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -7161,14 +10193,13 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Weather Conditions",
-                    "id": "c3920f23-47ba-11ec-a7dd-c10f8e2a7b83",
-                    "answerType": "advancedDropDown",
+                    "id": "11791f89-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdownMultiSelect",
                     "display": [
                         "road"
                     ],
                     "humanReadableId": "road-weatherConditions",
                     "helperText": "(choose up to 2)",
-                    "autoMethod": "weather",
                     "answerOptions": [
                         {
                             "name": "Clear",
@@ -7223,7 +10254,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Light Condition",
-                    "id": "c3920f24-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8a-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7263,7 +10294,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Roadway Surface Condition",
-                    "id": "c3920f25-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8b-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7319,7 +10350,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "2.0",
                     "question": "Contributing Circumstances - Roadway Environment",
-                    "id": "c3920f26-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8c-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdownMultiSelect",
                     "display": [
                         "road"
@@ -7416,7 +10447,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Type of Intersection",
-                    "id": "c3920f27-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8d-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -7426,7 +10457,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Number of Approaches",
-                    "id": "c3920f28-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8e-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7459,7 +10490,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Overall Intersection Geometry",
-                    "id": "c3920f29-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f8f-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7488,7 +10519,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Overall Traffic Control Device",
-                    "id": "c3920f2a-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f90-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7525,7 +10556,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "0.0",
                     "question": "Work Zone-Related (Constrution/Maintenance/Utility)",
-                    "id": "c3920f2b-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f91-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "questionHeader",
                     "display": [
                         "road"
@@ -7536,7 +10567,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Was the crash work-zone related?",
-                    "id": "c3920f2c-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f92-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7562,7 +10593,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Location of the Crash",
-                    "id": "c3920f2d-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f93-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7571,7 +10602,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-workzoneRelated",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f92-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -7604,7 +10636,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Type of Work Zone",
-                    "id": "c3920f2e-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f94-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "dropdown",
                     "display": [
                         "road"
@@ -7613,7 +10645,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-workzoneRelated",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f92-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -7646,7 +10679,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Workers Present?",
-                    "id": "c3920f2f-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f95-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7655,7 +10688,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-workzoneRelated",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f92-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -7680,7 +10714,7 @@ export const questions = {
                 {
                     "numOptionsAllowed": "1.0",
                     "question": "Law Enforcement Present?",
-                    "id": "c3920f30-47ba-11ec-a7dd-c10f8e2a7b83",
+                    "id": "11791f96-52dc-11ec-9691-d109d8c8abd2",
                     "answerType": "multiButton",
                     "display": [
                         "road"
@@ -7689,7 +10723,8 @@ export const questions = {
                     "questionDependency": [
                         {
                             "dependencyName": "road-workzoneRelated",
-                            "dependencyOptionCode": "1"
+                            "dependencyOptionCode": "1.0",
+                            "dependencyUuid": "11791f92-52dc-11ec-9691-d109d8c8abd2"
                         }
                     ],
                     "answerOptions": [
@@ -7706,6 +10741,638 @@ export const questions = {
                             "id": "2.0"
                         }
                     ]
+                }
+            ],
+            "display": [
+                "road"
+            ]
+        },
+        {
+            "sectionTitle": "Additional Roadway Information",
+            "questions": [
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Bridge/Structure Identification Number",
+                    "id": "11791f98-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-bridgeStructureNum",
+                    "tooltip": "A unique federal inspection/inventory identifier assigned to a bridge, underpass, overpass, or tunnel bridge/structure that is also linkable to the National Bridge Inventory."
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Roadway Curvature",
+                    "id": "11791f99-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-curvature",
+                    "tooltip": "The measurement (in feet) of the curvature in the roadway expressed in terms of its radius, length, and superelevation. Obtained from the Roadway Inventory data."
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Curve Radius",
+                    "id": "11791f9a-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-curveRadius"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Length",
+                    "id": "11791f9b-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-length"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Superelevation",
+                    "id": "11791f9c-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-superelevation"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Grade",
+                    "id": "11791f9d-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-grade"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Direction of Slope",
+                    "id": "11791f9e-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-directionSlope",
+                    "tooltip": "Indicate up with a \"+\" and down with a \"-\""
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Percent of Slope",
+                    "id": "11791f9f-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-percentSlope"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Part of National Highway System",
+                    "id": "11791fa0-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-nationalHighway",
+                    "tooltip": "Is this road a part of the National Highway System?",
+                    "answerOptions": [
+                        {
+                            "name": "No",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Yes",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "2.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Roadway Functional Class: Rural or Urban",
+                    "id": "11791fa1-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-ruralUrban",
+                    "tooltip": "The character of service or function of streets or highways",
+                    "answerOptions": [
+                        {
+                            "name": "Rural",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Urban",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "2.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Roadway Functional Class: Specific Class",
+                    "id": "11791fa2-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": NaN,
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-specificClass",
+                    "answerOptions": [
+                        {
+                            "name": "Interstate",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Principal Arterial - Other Freeway or Expressway",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Principal Arterial - Other",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Minor Arterial",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Major Collector",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Minor Collector",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Local",
+                            "id": "6.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "7.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Annual Average Daily Traffic (AADT)",
+                    "id": "11791fa3-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-AADT"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "AADT (Year)",
+                    "id": "11791fa4-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-AADTYear",
+                    "tooltip": "The specific calendar year during which the AADT was calculated."
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "AADT (Value)",
+                    "id": "11791fa5-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-AADTValue"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Truck (over 10,000 lbs) Count or Percentage",
+                    "id": "11791fa6-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-truckCount"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Motorcycle Count or Percentage",
+                    "id": "11791fa7-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-motorcycleCount"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Widths of Lane(s) and Shoulder(s)",
+                    "id": "11791fa8-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-laneShoulderWidths"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Lane Width",
+                    "id": "11791fa9-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-laneWidth",
+                    "helperText": "(in feet)"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Left Shoulder Width",
+                    "id": "11791faa-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-leftShoulderWidth",
+                    "helperText": "(in feet)"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Right Shoulder Width",
+                    "id": "11791fab-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-rightShoulderWidth",
+                    "helperText": "(in feet)"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Width of Median",
+                    "id": "11791fac-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-medianWidth",
+                    "helperText": "(in feet)",
+                    "tooltip": "Width from the travel lane edge to travel lane edge of the portion of divided highway separating the road for traffic in opposing directions where the crash occurred. If a crash occurs at a mid-block section, the median width is based on the mid-block section. If the crash occurs at an intersection, the median width is based on the median widths at the intersection."
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Access Control",
+                    "id": "11791fad-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-accessControl",
+                    "tooltip": "The degree that access to abutting land is fully, partially, or not controlled by a public authority.\nFull access control: preference given to through traffic movements by providing interchanges with selected public roads, and by prohbiting crossing at-grade and direct driveway connections (ie, limited access to the facility).\nPartial access control: preference given to through traffic movement. In addition to interchanges, there may be some crossings at-grade with public roads, but direct private driveway connections have been minimized through th euse of frontage roads or other local access restrictions. Control of curb cuts is not access control.\nNo access control: no degree of access control exists; full access to the facility is permitted.\n",
+                    "answerOptions": [
+                        {
+                            "name": "No Access Control",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Partial Access Control",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Full Access Control",
+                            "id": "2.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Railway Crossing ID",
+                    "id": "11791fae-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-railwayCrossingId",
+                    "tooltip": "Unique US DOT/AAR number assigned for identification purposes to a railroad crossing by a State highway agency in cooperation with the Federal Railroad Administration."
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Roadway Lighting",
+                    "id": "11791faf-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-lighting",
+                    "answerOptions": [
+                        {
+                            "name": "Continuous Lighting on Both SIdes",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Continuous Lighting on One Side",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "No Lighting",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Spot Illumination on Both Sides",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Spot Illumination on One Side",
+                            "id": "4.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Pavement Markings, Longitudinal",
+                    "id": "11791fb0-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-pavementMarkings",
+                    "helperText": " us"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Edgeline Presence/Type",
+                    "id": "11791fb1-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-edgeline",
+                    "answerOptions": [
+                        {
+                            "name": "No Marked Edgeline",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Standard Width Edgeline",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Wide Edgeline",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Other",
+                            "id": "3.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Centerline Presence/Type",
+                    "id": "11791fb2-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-centerline",
+                    "answerOptions": [
+                        {
+                            "name": "No Marked Centerline",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Centerline with Centerline Rumble Stirp",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Standard Centerline Markings",
+                            "id": "2.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Lane Line Markings",
+                    "id": "11791fb3-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-laneLine",
+                    "answerOptions": [
+                        {
+                            "name": "No Lane Markings",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Standard Lane Line",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Wide Lane Line",
+                            "id": "2.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Presence/Type of Bicycle Facility",
+                    "id": "11791fb4-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-bicycleFacility"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Facility",
+                    "id": "11791fb5-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-facility",
+                    "answerOptions": [
+                        {
+                            "name": "None",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Marked Bicycle Lane",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Separated Bicycle Path/Trail",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unmarked Pave Shoulder",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Wide Curb Lane",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "5.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Signed Bicycle Route",
+                    "id": "11791fb6-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "dropdown",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-signedBicycleRoute",
+                    "answerOptions": [
+                        {
+                            "name": "No",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "Yes",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Not Applicable",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "3.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Mainline Number of Lanes at Intersection",
+                    "id": "11791fb7-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-mainlineLanesAtIntersection",
+                    "tooltip": "Number of through lanes on the mainline approaches of an intersection, including all lanes with through movement (through and left-turn, or through and right-turn) but not exclusive turn lanes.",
+                    "answerOptions": [
+                        {
+                            "name": "Not an Intersection or Interchange",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "One Lane",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Two Lanes",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Three Lanes",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Four to Six Lanes",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Seven or More Lanes",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "6.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Cross-Street Number of Lanes at Intersection",
+                    "id": "11791fb8-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "multiButton",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-crossStreetLanesAtIntersection",
+                    "tooltip": "Number of through lanes on the side-road approaches at intersection including all lanes with through movement (through and left-turn, or through and right-turn) but not exclusive turn lanes.",
+                    "answerOptions": [
+                        {
+                            "name": "Not an Intersection or Interchange",
+                            "id": "0.0"
+                        },
+                        {
+                            "name": "One Lane",
+                            "id": "1.0"
+                        },
+                        {
+                            "name": "Two Lanes",
+                            "id": "2.0"
+                        },
+                        {
+                            "name": "Three Lanes",
+                            "id": "3.0"
+                        },
+                        {
+                            "name": "Four to Six Lanes",
+                            "id": "4.0"
+                        },
+                        {
+                            "name": "Seven or More Lanes",
+                            "id": "5.0"
+                        },
+                        {
+                            "name": "Unknown",
+                            "id": "6.0"
+                        }
+                    ]
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Total Volume of Entering Vehicles",
+                    "id": "11791fb9-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "questionHeader",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-totalVolumeVehicles"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Year",
+                    "id": "11791fba-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-totalVolumeYear"
+                },
+                {
+                    "numOptionsAllowed": "nan",
+                    "question": "Value",
+                    "id": "11791fbb-52dc-11ec-9691-d109d8c8abd2",
+                    "answerType": "openTextBox",
+                    "display": [
+                        "road"
+                    ],
+                    "humanReadableId": "road-totalVolumeValue"
                 }
             ],
             "display": [

--- a/generate_questions.py
+++ b/generate_questions.py
@@ -2,13 +2,7 @@ import pandas as pd
 import json
 import uuid
 
-# sheets = ['construction', 'driver', 'fatalityDriver', 'fatalityNonmotorist',
-#             'info', 'injured', 'lvhm', 'lvhmDriver', 'nonmotorist', 'passenger',
-#             'road', 'setup', 'vehicle', 'answerOptions']
-
 question_sheets = ['driver', 'vehicle', 'nonmotorist', 'passenger', 'setup', 'road']
-# question_sheets = ['driver']
-# answer_sheets = ['driverAnswers']
 answer_sheets = ['driverAnswers', 'vehicleAnswers', 'nonmotoristAnswers', 'passengerAnswers', 'roadAnswers']
 
 def get_inverse_dependencies(name, option, df_answer):
@@ -16,13 +10,18 @@ def get_inverse_dependencies(name, option, df_answer):
     dependencies = []
     for index, row in df_sub_answer.iterrows():
         if str(row['option_number']) != option:
-            dependencies.append({'dependencyName':name, 'dependencyOptionCode':str(row['option_number'])})
+            dependencies.append({
+                'dependencyName': name, 
+                'dependencyOptionCode': str(float(row['option_number']))
+                })
     return dependencies
 
 def generate_questions_json(filename):
     questions_json = {'data': []}
     sections_df = pd.read_excel(filename, sheet_name=question_sheets)
     answers_df = pd.concat(pd.read_excel(filename, sheet_name=answer_sheets))
+
+    question_name_id_map = {}
 
     for section in sections_df:
         questions_df = sections_df[section]
@@ -36,18 +35,20 @@ def generate_questions_json(filename):
 
             question_uid = str(uuid.uuid1())
 
+            question_name_id_map[row['question_name']] = question_uid
+
             question_type = row['question_type']
 
             if question_type == 'sectionHeader':
                 if section_json != {}:
                     if section_json not in questions_json['data']:
                         questions_json['data'].append(section_json)
-                        print('added section to data', section_json['sectionTitle'])
+                        # print('added section to data', section_json['sectionTitle'])
 
                 section_json = {'sectionTitle': row['question_text'],
                                 'questions': [],
                                 'display': [row['display_section']]}
-                print('created new section', section_json['sectionTitle'])
+                # print('created new section', section_json['sectionTitle'])
 
             else:
                 question_dict = {'numOptionsAllowed': str(row['num_selected_option']),
@@ -55,8 +56,9 @@ def generate_questions_json(filename):
                                 'id': question_uid,
                                 'answerType': row['question_type'],
                                 'display': [row['display_section']],
-                                'humanReadableId': row['question_name']}
-                print(question_dict['question'])
+                                'humanReadableId': row['question_name']
+                                }
+                # print(question_dict['question'])
                 if pd.notna(row['helper_text']):
                     question_dict['helperText'] = row['helper_text']
                 if pd.notna(row['tooltip']):
@@ -77,9 +79,18 @@ def generate_questions_json(filename):
                             opposite_ds = get_inverse_dependencies(name, option[1:], answers_df)
                             questionDependency.extend(opposite_ds)
                         else:
-                            questionDependency.append({'dependencyName':name, 'dependencyOptionCode':str(option)})
+                            if int(option) >= 0:
+                                questionDependency.append({
+                                    'dependencyName': name, 
+                                    'dependencyOptionCode': str(float(option))
+                                })
+                            else:
+                                questionDependency.append({
+                                    'dependencyName': name,
+                                    'dependencyOptionCode': ''
+                                })
                     question_dict['questionDependency'] = questionDependency
-                    print('added dependencies', questionDependency)
+                    # print('added dependencies', questionDependency)
                 
                 question_name = row['question_name']
                 df_sub_answer = answers_df[answers_df['question_name'] == question_name]
@@ -95,71 +106,39 @@ def generate_questions_json(filename):
                 else:
                     questions_json['data'].append(question_dict)
             
-                print('added question', row['question_text'])
+                # print('added question', row['question_text'])
+
+            if section_json != {}:
+                if section_json not in questions_json['data']:
+                    questions_json['data'].append(section_json)
+                    print('added section to data', section_json['sectionTitle'])
+    
+    questions_data = questions_json['data']
+    for section in questions_data:
+        section_keys = section.keys()
+        if 'sectionTitle' in section_keys:
+            section_questions = section['questions']
+            for question in section_questions:
+                question_keys = question.keys()
+                if 'questionDependency' in question_keys:
+                    question_dependencies = question['questionDependency']
+                    for dependency in question_dependencies:
+                        dependency_name = dependency['dependencyName']
+                        dependency_uuid = question_name_id_map[dependency_name]
+                        dependency['dependencyUuid'] = dependency_uuid
+        else:
+            if 'questionDependency' in section_keys:
+                dependency = section['questionDependency']
+                dependency_name = dependency['dependencyName']
+                dependency_uuid = question_name_id_map[dependency_name]
+                dependency['dependencyUuid'] = dependency_uuid
+
+    questions_json['data'] = questions_data
 
     return questions_json
-                    
-
-# def generate_questions_json(filename):
-#     # create empty questions json file
-#     questions_json = {'data':[]}
-#     # make sure there are not duplicate question_uuids
-#     question_uids = []
-#     # read relevant sheets from excel file
-#     dfs = pd.read_excel(filename, sheet_name=sheets)
-#     # extract the answerOptions sheet
-#     df_answer = dfs[sheets[-1]]
-#     # iterate through the question sheets
-#     for section in sheets[:-1]:
-#         df_question = dfs[section]
-#         # go through each question in the question sheets
-#         for index, row in df_question.iterrows():
-#             if pd.isna(row['id']):
-#                 continue
-#             if row['question_uid'] in question_uids:
-#                 print('Duplicate uid at', row['display_section'], row['question_uid'])
-#             else:
-#                 question_uids.append(row['question_uid'])
-#             question_dict = {'numOptionsAllowed':str(row['num_selected_option']),
-#                                  'question':row['question_text'], 'id':row['question_uid'],
-#                                  'answerType':row['question_type'], 'display':[row['display_section']],
-#                                  'humanReadableId':row['id']}
-#             # add helper text, dependency, and auto method values if applicable
-#             if pd.notna(row['helper_text']):
-#                 question_dict['helperText'] = row['helper_text']
-#             if pd.notna(row['tooltip']):
-#                 question_dict['tooltip'] = row['tooltip']
-#             if pd.notna(row['helper_img']):
-#                 question_dict['helperImg'] = row['helper_img']
-#             if pd.notna(row['automation_method']):
-#                 question_dict['autoMethod'] = row['automation_method']
-#             if pd.notna(row['question_dependency']):
-#                 dependencies = row['question_dependency'].split(";")
-#                 questionDependency = []
-#                 for d in dependencies:
-#                     uid, option = d.split(",")
-#                     # deal with not dependencies
-#                     if "!" in option:
-#                         opposite_ds = get_inverse_dependencies(uid, option[1:], df_answer)
-#                         questionDependency.extend(opposite_ds)
-#                     else:
-#                         questionDependency.append({'dependencyUid':uid, 'dependencyOptionCode':str(option)})
-#                 question_dict['questionDependency'] = questionDependency
-#             # match question with relevant section in df_answer
-#             question_id = row['question_uid']
-#             df_sub_answer = df_answer[df_answer['question_uid']==question_id]
-#             if len(df_sub_answer) > 0:
-#                 # generate list of dicts from answer options
-#                 answer_options = []
-#                 for index2, row2 in df_sub_answer.iterrows():
-#                     answer_option_dict = {'name':row2['option_text'], 'id':str(row2['option_number'])}
-#                     answer_options.append(answer_option_dict)
-#                 question_dict['answerOptions'] = answer_options
-#             questions_json['data'].append(question_dict)
-#     return questions_json
 
 if __name__ == '__main__':
-    filename = '~/2021_11_16_questions.xlsx'
+    filename = '~/2021_12_01_questions.xlsx'
     new_filename = 'data/questions.js'
 
     json_data = generate_questions_json(filename)

--- a/utils/dependencyHelper.js
+++ b/utils/dependencyHelper.js
@@ -1,12 +1,12 @@
 export function dependencyParser(response, data, formID) {
-    console.log('dependencyId:', formID);
     var renderComponent = false;
     if (data.questionDependency == undefined) {
         renderComponent = true;
     } else if (response != null) {
+        console.log('data.questionDependency:', data.questionDependency);
         let tarQuesArr = data.questionDependency;
         for (let i = 0; i <tarQuesArr.length; i++) {
-            let tarName = tarQuesArr[i].dependencyName;
+            let tarUuid = tarQuesArr[i].dependencyUuid;
             let tarOptionCode = tarQuesArr[i].dependencyOptionCode
             var findResponse;
             for (let j = response.length-1; j >= 0; j--) {
@@ -14,17 +14,17 @@ export function dependencyParser(response, data, formID) {
                     let tarVehicle = formID[1]
                     switch (formID.length) {
                         case 2:
-                            if (response[j].question == tarName && response[j].vehicleID == tarVehicle){
+                            if (response[j].question == tarUuid && response[j].vehicleID == tarVehicle){
                                 findResponse = response[j]}
                             break;
                         case 3:
                             let tarPassenger = formID[2] 
-                            if (response[j].question == tarName && response[j].vehicleID == tarVehicle && response[j].passengerID == tarPassenger){
+                            if (response[j].question == tarUuid && response[j].vehicleID == tarVehicle && response[j].passengerID == tarPassenger){
                                 findResponse = response[j]}
                             break;
                         case 4:
                             let tarNonmotorist = formID[3]
-                            if (response[j].question == tarName && response[j].nonmotoristID == tarNonmotorist){
+                            if (response[j].question == tarUuid && response[j].nonmotoristID == tarNonmotorist){
                                 findResponse = response[j]}
                             break;
                         default:
@@ -34,22 +34,29 @@ export function dependencyParser(response, data, formID) {
                         break
                     }
                 }else{
-                    if (response[j].question == tarName){
+                    if (response[j].question == tarUuid){
                         findResponse = response[j]
                         break
                     }
                 }
             }
             if (findResponse){
+                console.log(findResponse.selection);
+                console.log('tarOptionCode:', tarOptionCode);
+                console.log(typeof(tarOptionCode));
                 if (typeof findResponse.selection == "object"){
+                    console.log('selection is object')
                     findResponse.selection.forEach(element => {
                         if (element == tarOptionCode){renderComponent = true}
                     });
-                } else if (findResponse.selection == tarOptionCode) {
+                } else if (findResponse.selection === tarOptionCode) {
+                    console.log('selection is not an object, selection and target option code match')
                     renderComponent = true
                 }
             }
         }
     }
+
+    console.log('value of render component:', renderComponent)
     return renderComponent
 }


### PR DESCRIPTION
# Description

In an earlier version, the question dependencies were not working, and some sections were simply not showing up in the form. These modifications to the Python script and dependency parser fix these issues. Dependency checking is still incredibly time-inefficient, so we should revisit this in the future.

# Testing
1. Run the app.
2. Pick a few dependencies in each form, referring to the spreadsheet, and confirm if they work.