### PR TITLE
[Ruin 254] Reset state when starting new report from export screen

### DIFF
--- a/src/screens/finalReport/FinalReport.js
+++ b/src/screens/finalReport/FinalReport.js
@@ -48,7 +48,15 @@ class FinalReport extends Component {
           console.warn(err);
         }
       };
+    resetState(){
+        const {
+            navigation
+        } = this.props
 
+
+        navigation.navigate('Welcome');
+        this.props.state = {}
+    }
     render(){
         const {
             navigation
@@ -86,7 +94,7 @@ class FinalReport extends Component {
         return (
           <SafeAreaView style={{flex:1}}>
             <TopNavigation title='Final Report' backButton navigation={navigation}>
-                <IconButton onPress={() => navigation.navigate('Welcome')} icon={<Icon color="white" size={25} name='file-document-outline'/>}  text='Start New Report'/>
+                <IconButton onPress={() => this.resetState()} icon={<Icon color="white" size={25} name='file-document-outline'/>}  text='Start New Report'/>
             </TopNavigation>
             <Center>
                 <VStack space={8}>


### PR DESCRIPTION
# Description

Before this fix, the app always repopulated itself with past contents every time you clicked Start New Report. After adding a function in FinalReport.js, this.props.state is set to {}, which effectively stops the repopulation of past values.

# Testing
1. open the app
2. populate the fields with values
3. go to export
4. start a new report
